### PR TITLE
Implement print_function future feature

### DIFF
--- a/compiler/block.py
+++ b/compiler/block.py
@@ -217,7 +217,8 @@ class ModuleBlock(Block):
     imports: A dict mapping fully qualified Go package names to Package objects.
   """
 
-  def __init__(self, full_package_name, runtime, libroot, filename, lines, future_features):
+  def __init__(self, full_package_name, runtime, libroot, filename, lines,
+               future_features):
     super(ModuleBlock, self).__init__(None, '<module>')
     self._full_package_name = full_package_name
     self._runtime = runtime
@@ -442,5 +443,5 @@ class FunctionBlockVisitor(BlockVisitor):
         raise util.ParseError(node, msg)
       self.vars[name] = Var(name, Var.TYPE_PARAM, arg_index=i)
 
-  def visit_Yield(self, unused_node):
+  def visit_Yield(self, unused_node): # pylint: disable=unused-argument
     self.is_generator = True

--- a/compiler/block.py
+++ b/compiler/block.py
@@ -62,7 +62,7 @@ class Block(object):
   _runtime = None
   _strings = None
   imports = None
-  future_features = None
+  _future_features = None
 
   def __init__(self, parent_block, name):
     self.parent_block = parent_block
@@ -104,6 +104,11 @@ class Block(object):
   @property
   def strings(self):
     return self._module_block._strings  # pylint: disable=protected-access
+
+  @property
+  def future_features(self):
+    # pylint: disable=protected-access
+    return self._module_block._future_features
 
   @abc.abstractmethod
   def bind_var(self, writer, name, value):
@@ -227,7 +232,7 @@ class ModuleBlock(Block):
     self._lines = lines
     self._strings = set()
     self.imports = {}
-    self.future_features = future_features
+    self._future_features = future_features
 
   def bind_var(self, writer, name, value):
     writer.write_checked_call1(

--- a/compiler/block.py
+++ b/compiler/block.py
@@ -62,6 +62,7 @@ class Block(object):
   _runtime = None
   _strings = None
   imports = None
+  future_features = None
 
   def __init__(self, parent_block, name):
     self.parent_block = parent_block
@@ -216,7 +217,7 @@ class ModuleBlock(Block):
     imports: A dict mapping fully qualified Go package names to Package objects.
   """
 
-  def __init__(self, full_package_name, runtime, libroot, filename, lines):
+  def __init__(self, full_package_name, runtime, libroot, filename, lines, future_features):
     super(ModuleBlock, self).__init__(None, '<module>')
     self._full_package_name = full_package_name
     self._runtime = runtime
@@ -225,6 +226,7 @@ class ModuleBlock(Block):
     self._lines = lines
     self._strings = set()
     self.imports = {}
+    self.future_features = future_features
 
   def bind_var(self, writer, name, value):
     writer.write_checked_call1(

--- a/compiler/block_test.py
+++ b/compiler/block_test.py
@@ -21,8 +21,8 @@ import textwrap
 import unittest
 
 from grumpy.compiler import block
+from grumpy.compiler import stmt
 from grumpy.compiler import util
-
 
 class PackageTest(unittest.TestCase):
 
@@ -243,7 +243,8 @@ class FunctionBlockVisitorTest(unittest.TestCase):
 
 
 def _MakeModuleBlock():
-  return block.ModuleBlock('__main__', 'grumpy', 'grumpy/lib', '<test>', [])
+  return block.ModuleBlock('__main__', 'grumpy', 'grumpy/lib', '<test>', [],
+                           stmt.FutureFeatures())
 
 
 def _ParseStmt(stmt_str):

--- a/compiler/expr_visitor_test.py
+++ b/compiler/expr_visitor_test.py
@@ -24,6 +24,7 @@ import unittest
 from grumpy.compiler import block
 from grumpy.compiler import expr_visitor
 from grumpy.compiler import shard_test
+from grumpy.compiler import stmt
 from grumpy.compiler import util
 
 
@@ -220,7 +221,8 @@ class ExprVisitorTest(unittest.TestCase):
 
 
 def _MakeModuleBlock():
-  return block.ModuleBlock('__main__', 'grumpy', 'grumpy/lib', '<test>', [])
+  return block.ModuleBlock('__main__', 'grumpy', 'grumpy/lib', '<test>', [],
+                           stmt.FutureFeatures())
 
 
 def _ParseExpr(expr):

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -56,9 +56,8 @@ redundant_future_features = ["generators", "with_statement", "nested_scopes"]
 late_future = 'from __future__ imports must occur at the beginning of the file'
 
 
-# import_from_future processes a future import statement, returning the set of
-# flags it defines.
 def import_from_future(node):
+  """processes a future import statement, returning set of flags it defines."""
   assert isinstance(node, ast.ImportFrom)
   assert node.module == '__future__'
   flags = 0
@@ -113,7 +112,7 @@ def visit_future(node):
         done = True
     elif isinstance(node, ast.Expr) and not found_docstring:
       e = node.value
-      if not isinstance(e, ast.Str):
+      if not isinstance(e, ast.Str): # pylint: disable=simplifiable-if-statement
         done = True
       else:
         found_docstring = True

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -57,7 +57,7 @@ late_future = 'from __future__ imports must occur at the beginning of the file'
 
 
 def import_from_future(node):
-  """processes a future import statement, returning set of flags it defines."""
+  """Processes a future import statement, returning set of flags it defines."""
   assert isinstance(node, ast.ImportFrom)
   assert node.module == '__future__'
   flags = 0
@@ -131,7 +131,6 @@ class StatementVisitor(ast.NodeVisitor):
     self.future_features = self.block.future_features or FutureFeatures()
     self.writer = util.Writer()
     self.expr_visitor = expr_visitor.ExprVisitor(self.block, self.writer)
-    self.parser_flags = getattr(block_, 'parser_flags', 0)
 
   def generic_visit(self, node):
     msg = 'node not yet implemented: {}'.format(type(node).__name__)

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -56,6 +56,72 @@ redundant_future_features = ["generators", "with_statement", "nested_scopes"]
 late_future = 'from __future__ imports must occur at the beginning of the file'
 
 
+# import_from_future processes a future import statement, returning the set of
+# flags it defines.
+def import_from_future(node):
+  assert isinstance(node, ast.ImportFrom)
+  assert node.module == '__future__'
+  flags = 0
+  for alias in node.names:
+    name = alias.name
+    if name in future_features:
+      flag, implemented = future_features[name]
+      if not implemented:
+        msg = 'future feature {} not yet implemented by grumpy'.format(name)
+        raise util.ParseError(node, msg)
+      flags |= flag
+    elif name == 'braces':
+      raise util.ParseError(node, 'not a chance')
+    elif name not in redundant_future_features:
+      msg = 'future feature {} is not defined'.format(name)
+      raise util.ParseError(node, msg)
+  return flags
+
+
+class FutureFeatures(object):
+  def __init__(self):
+    self.parser_flags = 0
+    self.future_lineno = 0
+
+
+def visit_future(node):
+  """Accumulates a set of compiler flags for the compiler __future__ imports.
+
+  Returns an instance of FutureFeatures which encapsulates the flags and the
+  line number of the last valid future import parsed. A downstream parser can
+  use the latter to detect invalid future imports that appear too late in the
+  file.
+  """
+  # If this is the module node, do an initial pass through the module body's
+  # statements to detect future imports and process their directives (i.e.,
+  # set compiler flags), and detect ones that don't appear at the beginning of
+  # the file. The only things that can proceed a future statement are other
+  # future statements and/or a doc string.
+  assert isinstance(node, ast.Module)
+  ff = FutureFeatures()
+  done = False
+  found_docstring = False
+  for node in node.body:
+    if isinstance(node, ast.ImportFrom):
+      modname = node.module
+      if modname == '__future__':
+        if done:
+          raise util.ParseError(node, late_future)
+        ff.parser_flags |= import_from_future(node)
+        ff.future_lineno = node.lineno
+      else:
+        done = True
+    elif isinstance(node, ast.Expr) and not found_docstring:
+      e = node.value
+      if not isinstance(e, ast.Str):
+        done = True
+      else:
+        found_docstring = True
+    else:
+      done = True
+  return ff
+
+
 class StatementVisitor(ast.NodeVisitor):
   """Outputs Go statements to a Writer for the given Python nodes."""
 
@@ -63,42 +129,10 @@ class StatementVisitor(ast.NodeVisitor):
 
   def __init__(self, block_):
     self.block = block_
+    self.future_features = self.block.future_features or FutureFeatures()
     self.writer = util.Writer()
     self.expr_visitor = expr_visitor.ExprVisitor(self.block, self.writer)
-    self.parser_flags = 0
-    self.did_future_pass = False
-    self.future_lineno = 0
-
-  def visit(self, node):
-    root = node
-    # If this is the module node, do an initial pass through the module body's
-    # statements to detect future imports and process their directives (i.e.,
-    # set compiler flags), and detect ones that don't appear at the beginning of
-    # the file. The only things that can proceed a future statement are other
-    # future statements and/or a doc string.
-    if not self.did_future_pass and isinstance(node, ast.Module):
-      self.did_future_pass = True
-      done = False
-      found_docstring = False
-      for node in node.body:
-        if isinstance(node, ast.ImportFrom):
-          modname = node.module
-          if modname == '__future__':
-            if done:
-              raise util.ParseError(node, late_future)
-            self._handle_import_from_future(node)
-            self.future_lineno = node.lineno
-          else:
-            done = True
-        elif isinstance(node, ast.Expr) and not found_docstring:
-          e = node.value
-          if not isinstance(e, ast.Str):
-            done = True
-          else:
-            found_docstring = True
-        else:
-          done = True
-    super(StatementVisitor, self).visit(root)
+    self.parser_flags = getattr(block_, 'parser_flags', 0)
 
   def generic_visit(self, node):
     msg = 'node not yet implemented: {}'.format(type(node).__name__)
@@ -348,7 +382,7 @@ class StatementVisitor(ast.NodeVisitor):
       # At this stage all future imports are done in an initial pass (see
       # visit() above), so if they are encountered here after the last valid
       # __future__ then it's a syntax error.
-      if node.lineno > self.future_lineno:
+      if node.lineno > self.future_features.future_lineno:
         raise util.ParseError(node, late_future)
     else:
       # NOTE: Assume that the names being imported are all modules within a
@@ -369,7 +403,7 @@ class StatementVisitor(ast.NodeVisitor):
     self._write_py_context(node.lineno)
 
   def visit_Print(self, node):
-    if self.parser_flags & FUTURE_PRINT_FUNCTION:
+    if self.future_features.parser_flags & FUTURE_PRINT_FUNCTION:
       raise util.ParseError(node, 'syntax error (print is not a keyword)')
     self._write_py_context(node.lineno)
     with self.block.alloc_temp('[]*πg.Object') as args:
@@ -751,20 +785,3 @@ class StatementVisitor(ast.NodeVisitor):
       line = self.block.lines[lineno - 1].strip()
       self.writer.write('// line {}: {}'.format(lineno, line))
       self.writer.write('πF.SetLineno({})'.format(lineno))
-
-  def _handle_import_from_future(self, node):
-    assert isinstance(node, ast.ImportFrom)
-    assert node.module == '__future__'
-    for alias in node.names:
-      name = alias.name
-      if name in future_features:
-        flag, implemented = future_features[name]
-        if not implemented:
-          msg = 'future feature {} not yet implemented by grumpy'.format(name)
-          raise util.ParseError(node, msg)
-        self.parser_flags |= flag
-      elif name == 'braces':
-        raise util.ParseError(node, 'not a chance')
-      elif name not in redundant_future_features:
-        msg = 'future feature {} is not defined'.format(name)
-        raise util.ParseError(node, msg)

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -313,15 +313,12 @@ class StatementVisitor(ast.NodeVisitor):
       for alias in node.names:
         name = alias.name
         if name in future_features:
-          (flag, implemented) = future_features[name]
+          flag, implemented = future_features[name]
           if not implemented:
             msg = 'future feature {} not yet implemented by grumpy'.format(name)
-            raise util.ParseError(msg)
+            raise util.ParseError(node, msg)
           self.parser_flags |= flag
-        elif name in redundant_future_features:
-          # no-op
-          pass
-        else:
+        elif name not in redundant_future_features:
           msg = 'future feature {} is not defined'.format(name)
           raise util.ParseError(node, msg)
     else:

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -34,19 +34,19 @@ _nil_expr = expr.nil_expr
 
 # Parser flags, set on 'from __future__ import *', see parser_flags on
 # StatementVisitor below. Note these have the same values as CPython.
-FUTURE_DIVISION         =  0x2000
-FUTURE_ABSOLUTE_IMPORT  =  0x4000
-FUTURE_PRINT_FUNCTION   = 0x10000
+FUTURE_DIVISION = 0x2000
+FUTURE_ABSOLUTE_IMPORT = 0x4000
+FUTURE_PRINT_FUNCTION = 0x10000
 FUTURE_UNICODE_LITERALS = 0x20000
 
 # Names for future features in 'from __future__ import *'. Map from name in the
 # import statement to a tuple of the flag for parser, and whether we've (grumpy)
 # implemented the feature yet.
 future_features = {
-  "division"         : (FUTURE_DIVISION, False),
-  "absolute_import"  : (FUTURE_ABSOLUTE_IMPORT, False),
-  "print_function"   : (FUTURE_PRINT_FUNCTION, True),
-  "unicode_literals" : (FUTURE_UNICODE_LITERALS, False),
+    "division": (FUTURE_DIVISION, False),
+    "absolute_import": (FUTURE_ABSOLUTE_IMPORT, False),
+    "print_function": (FUTURE_PRINT_FUNCTION, True),
+    "unicode_literals": (FUTURE_UNICODE_LITERALS, False),
 }
 
 # These future features are already in the language proper as of 2.6, so
@@ -370,8 +370,7 @@ class StatementVisitor(ast.NodeVisitor):
 
   def visit_Print(self, node):
     if self.parser_flags & FUTURE_PRINT_FUNCTION:
-      raise util.ParseError(
-        node, 'syntax error (print is not a keyword)')
+      raise util.ParseError(node, 'syntax error (print is not a keyword)')
     self._write_py_context(node.lineno)
     with self.block.alloc_temp('[]*πg.Object') as args:
       self.writer.write('{} = make([]*πg.Object, {})'.format(

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -295,10 +295,10 @@ class StatementVisitorTest(unittest.TestCase):
 
   def testImportFromFuture(self):
     testcases = [
-      ('from __future__ import print_function', stmt.FUTURE_PRINT_FUNCTION),
-      ('from __future__ import generators', 0),
-      ('from __future__ import generators, print_function',
-       stmt.FUTURE_PRINT_FUNCTION),
+        ('from __future__ import print_function', stmt.FUTURE_PRINT_FUNCTION),
+        ('from __future__ import generators', 0),
+        ('from __future__ import generators, print_function',
+         stmt.FUTURE_PRINT_FUNCTION),
     ]
 
     for i, tc in enumerate(testcases):
@@ -311,14 +311,18 @@ class StatementVisitorTest(unittest.TestCase):
 
   def testImportFromFutureParseError(self):
     testcases = [
-      # NOTE: move these to testImportFromFuture as they are implemented by grumpy
-      ('from __future__ import absolute_import', r'future feature \w+ not yet implemented'),
-      ('from __future__ import division', r'future feature \w+ not yet implemented'),
-      ('from __future__ import unicode_literals', r'future feature \w+ not yet implemented'),
+        # NOTE: move this group to testImportFromFuture as they are implemented
+        # by grumpy
+        ('from __future__ import absolute_import',
+         r'future feature \w+ not yet implemented'),
+        ('from __future__ import division',
+         r'future feature \w+ not yet implemented'),
+        ('from __future__ import unicode_literals',
+         r'future feature \w+ not yet implemented'),
 
-      ('from __future__ import braces', 'not a chance'),
-      ('from __future__ import nonexistant_feature',
-       r'future feature \w+ is not defined'),
+        ('from __future__ import braces', 'not a chance'),
+        ('from __future__ import nonexistant_feature',
+         r'future feature \w+ is not defined'),
     ]
 
     for tc in testcases:
@@ -330,11 +334,19 @@ class StatementVisitorTest(unittest.TestCase):
 
   def testVisitFuture(self):
     testcases = [
-      ('from __future__ import print_function', stmt.FUTURE_PRINT_FUNCTION, 1),
-      ("""\
-      "module docstring"
-      from __future__ import print_function
-      """, stmt.FUTURE_PRINT_FUNCTION, 2),
+        ('from __future__ import print_function',
+         stmt.FUTURE_PRINT_FUNCTION, 1),
+        ("""\
+        "module docstring"
+
+        from __future__ import print_function
+        """, stmt.FUTURE_PRINT_FUNCTION, 3),
+        ("""\
+        "module docstring"
+
+        from __future__ import print_function, with_statement
+        from __future__ import nested_scopes
+        """, stmt.FUTURE_PRINT_FUNCTION, 4),
     ]
 
     for tc in testcases:
@@ -346,16 +358,16 @@ class StatementVisitorTest(unittest.TestCase):
 
   def testVisitFutureParseError(self):
     testcases = [
-      # future after normal imports
-      """\
-      import os
-      from __future__ import print_function
-      """,
-      # future after non-docstring expression 
-      """
-      asd = 123
-      from __future__ import print_function
-      """
+        # future after normal imports
+        """\
+        import os
+        from __future__ import print_function
+        """,
+        # future after non-docstring expression
+        """
+        asd = 123
+        from __future__ import print_function
+        """
     ]
 
     for source in testcases:
@@ -373,15 +385,6 @@ class StatementVisitorTest(unittest.TestCase):
         print('abc', 123)
         print('abc', 123, sep='x')
         print('abc', 123, end=' ')""")))
-
-  def testUnimplementedFutureFeature(self):
-    regexp = r'future feature \w+ not yet implemented'
-    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
-                            'from __future__ import division')
-
-  def testMatchCPythonFutureBraces(self):
-    self.assertRaisesRegexp(util.ParseError, 'not a chance', _ParseAndVisit,
-                            'from __future__ import braces')
 
   def testRaiseExitStatus(self):
     self.assertEqual(1, _GrumpRun('raise Exception')[0])

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -303,6 +303,11 @@ class StatementVisitorTest(unittest.TestCase):
         print('abc', 123, sep='x')
         print('abc', 123, end=' ')""")))
 
+  def testUnimplementedFutureFeature(self):
+    regexp = r'future feature \w+ not yet implemented'
+    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
+                            'from __future__ import division')
+
   def testRaiseExitStatus(self):
     self.assertEqual(1, _GrumpRun('raise Exception')[0])
 

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -294,7 +294,7 @@ class StatementVisitorTest(unittest.TestCase):
         print 'foo', 'bar'""")))
 
   def testFutureImportProcessingRules(self):
-    class testcase(object):
+    class TestCase(object):
       def __init__(self, source, syntax_error=False):
         self.source = source
         self.syntax_error = syntax_error
@@ -302,27 +302,27 @@ class StatementVisitorTest(unittest.TestCase):
     err = r'from __future__ imports must occur at the beginning of the file'
 
     tests = [
-      testcase('from __future__ import print_function'),
-      testcase("""
-        "module docstring"
-        from __future__ import with_statement
-      """),
-      testcase("""
-        asd = 123
-        from __future__ import with_statement
-      """, syntax_error=True),
-      testcase("""
-        from __future__ import with_statement
-        from __future__ import print_function
-      """),
-      testcase("""
-        import os
-        from __future__ import with_statement
-      """, syntax_error=True),
-      testcase("""
-        def foo():
-            from __future__ import with_statement
-      """, syntax_error=True),
+        TestCase('from __future__ import print_function'),
+        TestCase("""
+          "module docstring"
+          from __future__ import with_statement
+        """),
+        TestCase("""
+          asd = 123
+          from __future__ import with_statement
+        """, syntax_error=True),
+        TestCase("""
+          from __future__ import with_statement
+          from __future__ import print_function
+        """),
+        TestCase("""
+          import os
+          from __future__ import with_statement
+        """, syntax_error=True),
+        TestCase("""
+          def foo():
+              from __future__ import with_statement
+        """, syntax_error=True),
     ]
 
     for tc in tests:
@@ -331,8 +331,8 @@ class StatementVisitorTest(unittest.TestCase):
         self.assertEqual(0, exit_code)
       else:
         self.assertRaisesRegexp(
-          util.ParseError, err, _ParseAndVisit,
-          textwrap.dedent(tc.source))
+            util.ParseError, err, _ParseAndVisit,
+            textwrap.dedent(tc.source))
 
   def testFutureFeaturePrintFunction(self):
     want = "abc\n123\nabc 123\nabcx123\nabc 123 "

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -287,11 +287,21 @@ class StatementVisitorTest(unittest.TestCase):
         from __go__.time import type_Duration as Duration
         print Duration""")))
 
-  def testPrint(self):
+  def testPrintStatement(self):
     self.assertEqual((0, 'abc 123\nfoo bar\n'), _GrumpRun(textwrap.dedent("""\
         print 'abc',
         print '123'
         print 'foo', 'bar'""")))
+
+  def testFutureFeaturePrintFunction(self):
+    want = "abc\n123\nabc 123\nabcx123\nabc 123 "
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import print_function
+        print('abc')
+        print(123)
+        print('abc', 123)
+        print('abc', 123, sep='x')
+        print('abc', 123, end=' ')""")))
 
   def testRaiseExitStatus(self):
     self.assertEqual(1, _GrumpRun('raise Exception')[0])

--- a/compiler/util_test.py
+++ b/compiler/util_test.py
@@ -20,6 +20,7 @@ import unittest
 
 from grumpy.compiler import block
 from grumpy.compiler import util
+from grumpy.compiler import stmt
 
 
 class WriterTest(unittest.TestCase):
@@ -34,8 +35,9 @@ class WriterTest(unittest.TestCase):
 
   def testWriteBlock(self):
     writer = util.Writer()
-    writer.write_block(block.ModuleBlock(
-        '__main__', 'grumpy', 'grumpy/lib', '<test>', []), 'BODY')
+    mod_block = block.ModuleBlock('__main__', 'grumpy', 'grumpy/lib', '<test>',
+                                  [], stmt.FutureFeatures())
+    writer.write_block(mod_block, 'BODY')
     output = writer.out.getvalue()
     dispatch = 'switch πF.State() {\n\tcase 0:\n\tdefault: panic'
     self.assertIn(dispatch, output)

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -17,6 +17,7 @@ package grumpy
 import (
 	"fmt"
 	"math/big"
+	"os"
 	"unicode"
 )
 
@@ -431,6 +432,44 @@ func builtinOrd(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	return NewInt(result).ToObject(), nil
 }
 
+func builtinPrint(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+	sep := " "
+	end := "\n"
+	file := os.Stdout
+	for _, kwarg := range kwargs {
+		switch kwarg.Name {
+		case "sep":
+			kwsep, raised := ToStr(f, kwarg.Value)
+			if raised != nil {
+				return nil, raised
+			}
+			sep = kwsep.Value()
+		case "end":
+			kwend, raised := ToStr(f, kwarg.Value)
+			if raised != nil {
+				return nil, raised
+			}
+			end = kwend.Value()
+		case "file":
+			// TODO: need to map Python sys.stdout, sys.stderr etc. to
+			// os.Stdout, os.Stderr, but for other file-like objects would need
+			// to recover to the file descriptor probably
+		}
+	}
+	for i, arg := range args {
+		if i > 0 {
+			fmt.Fprint(file, sep)
+		}
+		s, raised := ToStr(f, arg)
+		if raised != nil {
+			return nil, raised
+		}
+		fmt.Fprint(file, s.Value())
+	}
+	fmt.Fprint(file, end)
+	return nil, nil
+}
+
 func builtinRange(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	r, raised := xrangeType.Call(f, args, nil)
 	if raised != nil {
@@ -486,6 +525,7 @@ func init() {
 		"oct":            newBuiltinFunction("oct", builtinOct).ToObject(),
 		"open":           newBuiltinFunction("open", builtinOpen).ToObject(),
 		"ord":            newBuiltinFunction("ord", builtinOrd).ToObject(),
+		"print":          newBuiltinFunction("print", builtinPrint).ToObject(),
 		"range":          newBuiltinFunction("range", builtinRange).ToObject(),
 		"repr":           newBuiltinFunction("repr", builtinRepr).ToObject(),
 		"True":           True.ToObject(),

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -451,23 +451,12 @@ func builtinPrint(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) 
 			}
 			end = kwend.Value()
 		case "file":
-			// TODO: need to map Python sys.stdout, sys.stderr etc. to
-			// os.Stdout, os.Stderr, but for other file-like objects would need
-			// to recover to the file descriptor probably
+			// TODO: need to map Python sys.stdout, sys.stderr etc. to os.Stdout,
+			// os.Stderr, but for other file-like objects would need to recover
+			// to the file descriptor probably
 		}
 	}
-	for i, arg := range args {
-		if i > 0 {
-			fmt.Fprint(file, sep)
-		}
-		s, raised := ToStr(f, arg)
-		if raised != nil {
-			return nil, raised
-		}
-		fmt.Fprint(file, s.Value())
-	}
-	fmt.Fprint(file, end)
-	return nil, nil
+	return nil, pyPrint(f, args, sep, end, file)
 }
 
 func builtinRange(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -15,8 +15,11 @@
 package grumpy
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"math/big"
+	"os"
 	"testing"
 )
 
@@ -208,5 +211,57 @@ func TestNoneRepr(t *testing.T) {
 	cas := invokeTestCase{args: wrapArgs(None), want: NewStr("None").ToObject()}
 	if err := runInvokeMethodTestCase(NoneType, "__repr__", &cas); err != "" {
 		t.Error(err)
+	}
+}
+
+// captureStdout invokes a function closure which writes to stdout and captures
+// its output as string.
+func captureStdout(f *Frame, fn func() *BaseException) (string, *BaseException) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", f.RaiseType(RuntimeErrorType, fmt.Sprintf("failed to open pipe: %v", err))
+	}
+	oldStdout := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+	done := make(chan struct{})
+	var raised *BaseException
+	go func() {
+		defer close(done)
+		defer w.Close()
+		raised = fn()
+	}()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return "", f.RaiseType(RuntimeErrorType, fmt.Sprintf("failed to copy buffer: %v", err))
+	}
+	<-done
+	if raised != nil {
+		return "", raised
+	}
+	return buf.String(), nil
+}
+
+func TestBuiltinPrint(t *testing.T) {
+	fun := wrapFuncForTest(func(f *Frame, args *Tuple, kwargs KWArgs) (string, *BaseException) {
+		return captureStdout(f, func() *BaseException {
+			_, raised := builtinPrint(newFrame(nil), args.elems, kwargs)
+			return raised
+		})
+	})
+	cases := []invokeTestCase{
+		{args: wrapArgs(NewTuple(), wrapKWArgs()), want: NewStr("\n").ToObject()},
+		{args: wrapArgs(newTestTuple("abc"), wrapKWArgs()), want: NewStr("abc\n").ToObject()},
+		{args: wrapArgs(newTestTuple("abc", 123), wrapKWArgs()), want: NewStr("abc 123\n").ToObject()},
+		{args: wrapArgs(newTestTuple("abc", 123), wrapKWArgs("sep", "")), want: NewStr("abc123\n").ToObject()},
+		{args: wrapArgs(newTestTuple("abc", 123), wrapKWArgs("end", "")), want: NewStr("abc 123").ToObject()},
+		{args: wrapArgs(newTestTuple("abc", 123), wrapKWArgs("sep", "XX", "end", "--")), want: NewStr("abcXX123--").ToObject()},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(fun, &cas); err != "" {
+			t.Error(err)
+		}
 	}
 }

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -550,22 +550,6 @@ func Next(f *Frame, iter *Object) (*Object, *BaseException) {
 	return next.Fn(f, iter)
 }
 
-// pyPrint encapsulates the logic of the Python print function.
-func pyPrint(f *Frame, args Args, sep, end string, file io.Writer) *BaseException {
-	for i, arg := range args {
-		if i > 0 {
-			fmt.Fprint(file, sep)
-		}
-		s, raised := ToStr(f, arg)
-		if raised != nil {
-			return raised
-		}
-		fmt.Fprint(file, s.Value())
-	}
-	fmt.Fprint(file, end)
-	return nil
-}
-
 // Print implements the Python print statement. It calls str() on the given args
 // and outputs the results to stdout separated by spaces. Similar to the Python
 // print statement.
@@ -986,4 +970,21 @@ func checkMethodVarArgs(f *Frame, method string, args Args, types ...*Type) *Bas
 
 func hashNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
 	return nil, f.RaiseType(TypeErrorType, fmt.Sprintf("unhashable type: '%s'", o.typ.Name()))
+}
+
+// pyPrint encapsulates the logic of the Python print function.
+func pyPrint(f *Frame, args Args, sep, end string, file io.Writer) *BaseException {
+	for i, arg := range args {
+		if i > 0 {
+			fmt.Fprint(file, sep)
+		}
+		s, raised := ToStr(f, arg)
+		if raised != nil {
+			log.Printf("*** RAISED: %v", raised)
+			return raised
+		}
+		fmt.Fprint(file, s.Value())
+	}
+	fmt.Fprint(file, end)
+	return nil
 }

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -980,7 +980,6 @@ func pyPrint(f *Frame, args Args, sep, end string, file io.Writer) *BaseExceptio
 		}
 		s, raised := ToStr(f, arg)
 		if raised != nil {
-			log.Printf("*** RAISED: %v", raised)
 			return raised
 		}
 		fmt.Fprint(file, s.Value())

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -17,9 +17,7 @@ package grumpy
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math/big"
-	"os"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -643,33 +641,33 @@ func TestInvokeKeywordArgs(t *testing.T) {
 	}
 }
 
-func TestPrint(t *testing.T) {
-	fun := wrapFuncForTest(func(f *Frame, args *Tuple, nl bool) (string, *BaseException) {
-		r, w, err := os.Pipe()
-		if err != nil {
-			return "", f.RaiseType(RuntimeErrorType, fmt.Sprintf("failed to open pipe: %v", err))
-		}
-		oldStdout := os.Stdout
-		os.Stdout = w
-		defer func() {
-			os.Stdout = oldStdout
-		}()
-		done := make(chan struct{})
-		var raised *BaseException
-		go func() {
-			defer close(done)
-			defer w.Close()
-			raised = Print(NewRootFrame(), args.elems, nl)
-		}()
+func TestPyPrint(t *testing.T) {
+	fun := wrapFuncForTest(func(f *Frame, args *Tuple, sep, end string) (string, *BaseException) {
 		var buf bytes.Buffer
-		if _, err := io.Copy(&buf, r); err != nil {
-			return "", f.RaiseType(RuntimeErrorType, fmt.Sprintf("failed to copy buffer: %v", err))
-		}
-		<-done
+		raised := pyPrint(NewRootFrame(), args.elems, sep, end, &buf)
 		if raised != nil {
 			return "", raised
 		}
 		return buf.String(), nil
+	})
+	cases := []invokeTestCase{
+		{args: wrapArgs(NewTuple(), "", "\n"), want: NewStr("\n").ToObject()},
+		{args: wrapArgs(NewTuple(), "", ""), want: NewStr("").ToObject()},
+		{args: wrapArgs(newTestTuple("abc", 123), " ", "\n"), want: NewStr("abc 123\n").ToObject()},
+		{args: wrapArgs(newTestTuple("foo"), "", " "), want: NewStr("foo ").ToObject()},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(fun, &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
+func TestPrint(t *testing.T) {
+	fun := wrapFuncForTest(func(f *Frame, args *Tuple, nl bool) (string, *BaseException) {
+		return captureStdout(f, func() *BaseException {
+			return Print(NewRootFrame(), args.elems, nl)
+		})
 	})
 	cases := []invokeTestCase{
 		{args: wrapArgs(NewTuple(), true), want: NewStr("\n").ToObject()},

--- a/tools/grumpc
+++ b/tools/grumpc
@@ -49,9 +49,18 @@ def main(args):
     print >> sys.stderr, '{}: line {}: invalid syntax: {}'.format(
         e.filename, e.lineno, e.text)
     return 2
+
+  # Do a pass for compiler directives from `from __future__ import *` statements
+  try:
+    future_features = stmt.visit_future(mod)
+  except util.ParseError as e:
+    print >> sys.stderr, str(e)
+    return 2
+
   full_package_name = args.modname.replace('.', '/')
   mod_block = block.ModuleBlock(full_package_name, args.runtime, args.libroot,
-                                args.filename, py_contents.split('\n'))
+                                args.filename, py_contents.split('\n'),
+                                future_features)
   mod_block.add_native_import('grumpy')
   visitor = stmt.StatementVisitor(mod_block)
   # Indent so that the module body is aligned with the goto labels.


### PR DESCRIPTION
This allows the import statement `from __future__ import print_function` to work, by setting a flag on the parser to treat print statement/keyword as a syntax error, and adding support to the Go runtime as a builtin.

Addresses #22