### PR TITLE
Add support for the `callable` builtin

### DIFF
--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -230,6 +230,17 @@ func builtinBin(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	return NewStr(numberToBase("0b", 2, index)).ToObject(), nil
 }
 
+func builtinCallable(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+	if raised := checkFunctionArgs(f, "callable", args, ObjectType); raised != nil {
+		return nil, raised
+	}
+	o := args[0]
+	if call := o.Type().slots.Call; call == nil {
+		return False.ToObject(), nil
+	}
+	return True.ToObject(), nil
+}
+
 func builtinChr(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "chr", args, IntType); raised != nil {
 		return nil, raised
@@ -499,6 +510,7 @@ func init() {
 		"abs":            newBuiltinFunction("abs", builtinAbs).ToObject(),
 		"all":            newBuiltinFunction("all", builtinAll).ToObject(),
 		"bin":            newBuiltinFunction("bin", builtinBin).ToObject(),
+		"callable":       newBuiltinFunction("callable", builtinCallable).ToObject(),
 		"chr":            newBuiltinFunction("chr", builtinChr).ToObject(),
 		"dir":            newBuiltinFunction("dir", builtinDir).ToObject(),
 		"False":          False.ToObject(),

--- a/testing/builtin_test.py
+++ b/testing/builtin_test.py
@@ -54,3 +54,27 @@ except TypeError as e:
   assert str(e) == "'int' object is not iterable"
 else:
   raise AssertionError('this was supposed to raise an exception')
+
+# callable(x)
+
+assert not callable(1)
+assert not callable(0.1)
+
+assert not callable([1, 2, 3])
+assert not callable((1, 2, 3))
+assert not callable({'foo': 1, 'bar': 2})
+
+assert callable(lambda x: x+1)
+
+def foo(x):
+    pass
+
+assert callable(foo)
+
+class bar(object):
+    def __call__(self, *args, **kwargs):
+        pass
+
+assert callable(bar)
+assert callable(bar())
+


### PR DESCRIPTION
Implement the callable as defined here:

* https://docs.python.org/2.7/library/functions.html#callable

`make precommit` passed.

Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>