### PR TITLE
Implement namedtuple with type()

### DIFF
--- a/third_party/stdlib/collections.py
+++ b/third_party/stdlib/collections.py
@@ -258,29 +258,35 @@ class OrderedDict(dict):
 ### namedtuple
 ################################################################################
 
-_class_template = '''\
-class {typename}(tuple):
+class NamedTuple(tuple):
     '{typename}({arg_list})'
 
     __slots__ = ()
 
-    _fields = {field_names!r}
+    _fields = ()
 
-    def __new__(_cls, {arg_list}):
+    def __new__(_cls, *args, **kwds):
         'Create new instance of {typename}({arg_list})'
-        return _tuple.__new__(_cls, ({arg_list}))
+        try:
+            kwargs = tuple(map(kwds.pop, list(_cls._fields[len(args):])))
+        except KeyError as e:
+            raise TypeError('Unexpected keyword argument %r' % e.message)
+        return tuple.__new__(_cls, args + kwargs)
 
     @classmethod
     def _make(cls, iterable, new=tuple.__new__, len=len):
         'Make a new {typename} object from a sequence or iterable'
         result = new(cls, iterable)
-        if len(result) != {num_fields:d}:
-            raise TypeError('Expected {num_fields:d} arguments, got %d' % len(result))
+        n = len(cls._fields)
+        if len(result) != n:
+            raise TypeError('Expected %d arguments, got %d' % (n, len(result)))
         return result
 
     def __repr__(self):
         'Return a nicely formatted representation string'
-        return '{typename}({repr_fmt})' % self
+        values = (getattr(self, name) for name in self._fields)
+        attrstring = ', '.join('%s=%r' % (k, v) for k, v in zip(self._fields, values))
+        return '%s(%s)' % (self.__class__.__name__, attrstring)
 
     def _asdict(self):
         'Return a new OrderedDict which maps field names to their values'
@@ -288,7 +294,7 @@ class {typename}(tuple):
 
     def _replace(_self, **kwds):
         'Return a new {typename} object replacing specified fields with new values'
-        result = _self._make(map(kwds.pop, {field_names!r}, _self))
+        result = _self._make(map(kwds.pop, list(_self._fields), _self))
         if kwds:
             raise ValueError('Got unexpected field names: %r' % kwds.keys())
         return result
@@ -297,117 +303,107 @@ class {typename}(tuple):
         'Return self as a plain tuple.  Used by copy and pickle.'
         return tuple(self)
 
-    __dict__ = _property(_asdict)
+    __dict__ = property(_asdict)
 
     def __getstate__(self):
         'Exclude the OrderedDict from pickling'
         pass
 
-{field_defs}
-'''
 
-_repr_template = '{name}=%r'
+def namedtuple(typename, field_names, verbose=False, rename=False):
+    """Returns a new subclass of tuple with named fields. 
 
-_field_template = '''\
-    {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
-'''
+    >>> Point = namedtuple('Point', ['x', 'y'])
+    >>> Point.__doc__                   # docstring for the new class
+    'Point(x, y)'
+    >>> p = Point(11, y=22)             # instantiate with positional args or keywords
+    >>> p[0] + p[1]                     # indexable like a plain tuple
+    33
+    >>> x, y = p                        # unpack like a regular tuple
+    >>> x, y
+    (11, 22)
+    >>> p.x + p.y                       # fields also accessible by name
+    33
+    >>> d = p._asdict()                 # convert to a dictionary
+    >>> d['x']
+    11
+    >>> Point(**d)                      # convert from a dictionary
+    Point(x=11, y=22)
+    >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
+    Point(x=100, y=22)
 
-#def namedtuple(typename, field_names, verbose=False, rename=False):
-#    """Returns a new subclass of tuple with named fields.
-#
-#    >>> Point = namedtuple('Point', ['x', 'y'])
-#    >>> Point.__doc__                   # docstring for the new class
-#    'Point(x, y)'
-#    >>> p = Point(11, y=22)             # instantiate with positional args or keywords
-#    >>> p[0] + p[1]                     # indexable like a plain tuple
-#    33
-#    >>> x, y = p                        # unpack like a regular tuple
-#    >>> x, y
-#    (11, 22)
-#    >>> p.x + p.y                       # fields also accessible by name
-#    33
-#    >>> d = p._asdict()                 # convert to a dictionary
-#    >>> d['x']
-#    11
-#    >>> Point(**d)                      # convert from a dictionary
-#    Point(x=11, y=22)
-#    >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
-#    Point(x=100, y=22)
-#
-#    """
-#
-#    # Validate the field names.  At the user's option, either generate an error
-#    # message or automatically replace the field name with a valid name.
-#    if isinstance(field_names, basestring):
-#        field_names = field_names.replace(',', ' ').split()
-#    field_names = map(str, field_names)
-#    typename = str(typename)
-#    if rename:
-#        seen = set()
-#        for index, name in enumerate(field_names):
-#            if (not all(c.isalnum() or c=='_' for c in name)
-#                or _iskeyword(name)
-#                or not name
-#                or name[0].isdigit()
-#                or name.startswith('_')
-#                or name in seen):
-#                field_names[index] = '_%d' % index
-#            seen.add(name)
-#    for name in [typename] + field_names:
-#        if type(name) != str:
-#            raise TypeError('Type names and field names must be strings')
-#        if not all(c.isalnum() or c=='_' for c in name):
-#            raise ValueError('Type names and field names can only contain '
-#                             'alphanumeric characters and underscores: %r' % name)
-#        if _iskeyword(name):
-#            raise ValueError('Type names and field names cannot be a '
-#                             'keyword: %r' % name)
-#        if name[0].isdigit():
-#            raise ValueError('Type names and field names cannot start with '
-#                             'a number: %r' % name)
-#    seen = set()
-#    for name in field_names:
-#        if name.startswith('_') and not rename:
-#            raise ValueError('Field names cannot start with an underscore: '
-#                             '%r' % name)
-#        if name in seen:
-#            raise ValueError('Encountered duplicate field name: %r' % name)
-#        seen.add(name)
-#
-#    # Fill-in the class template
-#    class_definition = _class_template.format(
-#        typename = typename,
-#        field_names = tuple(field_names),
-#        num_fields = len(field_names),
-#        arg_list = repr(tuple(field_names)).replace("'", "")[1:-1],
-#        repr_fmt = ', '.join(_repr_template.format(name=name)
-#                             for name in field_names),
-#        field_defs = '\n'.join(_field_template.format(index=index, name=name)
-#                               for index, name in enumerate(field_names))
-#    )
-#    if verbose:
-#        print class_definition
-#
-#    # Execute the template string in a temporary namespace and support
-#    # tracing utilities by setting a value for frame.f_globals['__name__']
-#    namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
-#                     OrderedDict=OrderedDict, _property=property, _tuple=tuple)
-#    try:
-#        exec class_definition in namespace
-#    except SyntaxError as e:
-#        raise SyntaxError(e.message + ':\n' + class_definition)
-#    result = namespace[typename]
-#
-#    # For pickling to work, the __module__ variable needs to be set to the frame
-#    # where the named tuple is created.  Bypass this step in environments where
-#    # sys._getframe is not defined (Jython for example) or sys._getframe is not
-#    # defined for arguments greater than 0 (IronPython).
-#    try:
-#        result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
-#    except (AttributeError, ValueError):
-#        pass
-#
-#    return result
+    """
+
+    # Validate the field names.  At the user's option, either generate an error
+    # message or automatically replace the field name with a valid name.
+    if isinstance(field_names, basestring):
+        field_names = field_names.replace(',', ' ').split()
+    field_names = map(str, field_names)
+    typename = str(typename)
+    if rename:
+        seen = set()
+        for index, name in enumerate(field_names):
+            if (not all(c.isalnum() or c=='_' for c in name)
+                or _iskeyword(name)
+                or not name
+                or name[0].isdigit()
+                or name.startswith('_')
+                or name in seen):
+                field_names[index] = '_%d' % index
+            seen.add(name)
+    for name in [typename] + field_names:
+        if type(name) != str:
+            raise TypeError('Type names and field names must be strings')
+        if not all(c.isalnum() or c=='_' for c in name):
+            raise ValueError('Type names and field names can only contain '
+                             'alphanumeric characters and underscores: %r' % name)
+        if _iskeyword(name):
+            raise ValueError('Type names and field names cannot be a '
+                             'keyword: %r' % name)
+        if name[0].isdigit():
+            raise ValueError('Type names and field names cannot start with '
+                             'a number: %r' % name)
+    seen = set()
+    for name in field_names:
+        if name.startswith('_') and not rename:
+            raise ValueError('Field names cannot start with an underscore: '
+                             '%r' % name)
+        if name in seen:
+            raise ValueError('Encountered duplicate field name: %r' % name)
+        seen.add(name) 
+
+    # Grumpy doesn't like ``exec`` so we must create the new type in a
+    # different style. Base class instead of class template.
+    if verbose:
+        raise NotImplementedError('Grumpy does not exec the class definition') 
+
+    field_names = tuple(field_names)
+    arg_list = repr(field_names).replace("'", "")[1:-1]
+
+    bases = (NamedTuple,)
+    dictionary = {
+        '__slots__': (),
+        '_fields': field_names,
+        '__doc__': '%s(%s)' % (typename, arg_list)
+    }
+    for i, name in enumerate(field_names):
+        dictionary[name] = property(_itemgetter(i), doc='Alias for field number %d' % i)
+    result = type(typename, bases, dictionary)
+
+    result.__new__.__doc__ = result.__new__.__doc__.format(typename=typename, arg_list=arg_list)
+    result._make.__func__.__doc__ = result._make.__doc__.format(typename=typename)
+    result._replace.__func__.__doc__ = result._replace.__doc__.format(typename=typename)
+
+    # For pickling to work, the __module__ variable needs to be set to the frame
+    # where the named tuple is created.  Bypass this step in environments where
+    # sys._getframe is not defined (Jython for example) or sys._getframe is not
+    # defined for arguments greater than 0 (IronPython).
+    try:
+        result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
+
+    return result
 
 
 ########################################################################
@@ -717,37 +713,36 @@ class Counter(dict):
 
 
 if __name__ == '__main__':
-    pass
-#    # verify that instances can be pickled
-#    from cPickle import loads, dumps
-#    Point = namedtuple('Point', 'x, y', True)
-#    p = Point(x=10, y=20)
-#    assert p == loads(dumps(p))
-#
-#    # test and demonstrate ability to override methods
-#    class Point(namedtuple('Point', 'x y')):
-#        __slots__ = ()
-#        @property
-#        def hypot(self):
-#            return (self.x ** 2 + self.y ** 2) ** 0.5
-#        def __str__(self):
-#            return 'Point: x=%6.3f  y=%6.3f  hypot=%6.3f' % (self.x, self.y, self.hypot)
-#
-#    for p in Point(3, 4), Point(14, 5/7.):
-#        print p
-#
-#    class Point(namedtuple('Point', 'x y')):
-#        'Point class with optimized _make() and _replace() without error-checking'
-#        __slots__ = ()
-#        _make = classmethod(tuple.__new__)
-#        def _replace(self, _map=map, **kwds):
-#            return self._make(_map(kwds.get, ('x', 'y'), self))
-#
-#    print Point(11, 22)._replace(x=100)
-#
-#    Point3D = namedtuple('Point3D', Point._fields + ('z',))
-#    print Point3D.__doc__
-#
-#    import doctest
-#    TestResults = namedtuple('TestResults', 'failed attempted')
-#    print TestResults(*doctest.testmod())
+   # verify that instances can be pickled
+   from cPickle import loads, dumps
+   Point = namedtuple('Point', 'x, y')
+   p = Point(x=10, y=20)
+   assert p == loads(dumps(p))
+
+   # test and demonstrate ability to override methods
+   class Point(namedtuple('Point', 'x y')):
+       __slots__ = ()
+       @property
+       def hypot(self):
+           return (self.x ** 2 + self.y ** 2) ** 0.5
+       def __str__(self):
+           return 'Point: x=%6.3f  y=%6.3f  hypot=%6.3f' % (self.x, self.y, self.hypot)
+
+   for p in Point(3, 4), Point(14, 5/7.):
+       print p
+
+   class Point(namedtuple('Point', 'x y')):
+       'Point class with optimized _make() and _replace() without error-checking'
+       __slots__ = ()
+       _make = classmethod(tuple.__new__)
+       def _replace(self, _map=map, **kwds):
+           return self._make(_map(kwds.get, ('x', 'y'), self))
+
+   print Point(11, 22)._replace(x=100)
+
+   Point3D = namedtuple('Point3D', Point._fields + ('z',))
+   print Point3D.__doc__
+
+   # import doctest
+   # TestResults = namedtuple('TestResults', 'failed attempted')
+   # print TestResults(*doctest.testmod())


### PR DESCRIPTION
Grumpy does not allow exec'ing a class definition. This implementation
uses dynamic class creation via the ``type`` function. The
``NamedTuple`` class definition mimics the original interpolated class
definition template. The ``namedtuple`` function now needs to insert
attributes and properties into the class dictionary before the class is
created rather than interpolating those same things.

After the class is created, some method docstrings must be updated.

This code was tested using the rough test code in the main section, not
with a full battery of unit tests.