### PR TITLE
Adjust constants to work when compiling against 32bit architectures.

### DIFF
--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -84,7 +84,7 @@ func TestBuiltinFuncs(t *testing.T) {
 		{f: "hash", args: wrapArgs(123), want: NewInt(123).ToObject()},
 		{f: "hash", args: wrapArgs("foo"), want: hashFoo},
 		{f: "hash", args: wrapArgs(NewList()), wantExc: mustCreateException(TypeErrorType, "unhashable type: 'list'")},
-		{f: "hex", args: wrapArgs(0xd3adbeef), want: NewStr("0xd3adbeef").ToObject()},
+		{f: "hex", args: wrapArgs(0x63adbeef), want: NewStr("0x63adbeef").ToObject()},
 		{f: "hex", args: wrapArgs(0), want: NewStr("0x0").ToObject()},
 		{f: "hex", args: wrapArgs(1), want: NewStr("0x1").ToObject()},
 		{f: "hex", args: wrapArgs(-1), want: NewStr("-0x1").ToObject()},

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -329,7 +329,7 @@ func TestHash(t *testing.T) {
 	}))
 	o := newObject(ObjectType)
 	cases := []invokeTestCase{
-		{args: wrapArgs("foo"), want: NewInt(-4177197833195190597).ToObject()},
+		{args: wrapArgs("foo"), want: hashFoo},
 		{args: wrapArgs(123), want: NewInt(123).ToObject()},
 		{args: wrapArgs(o), want: NewInt(int(uintptr(o.toPointer()))).ToObject()},
 		{args: wrapArgs(NewList()), wantExc: mustCreateException(TypeErrorType, "unhashable type: 'list'")},
@@ -464,7 +464,7 @@ func TestIsTrue(t *testing.T) {
 		// Int
 		{args: wrapArgs(0), want: False.ToObject()},
 		{args: wrapArgs(-1020), want: True.ToObject()},
-		{args: wrapArgs(3698391283), want: True.ToObject()},
+		{args: wrapArgs(1698391283), want: True.ToObject()},
 		// None
 		{args: wrapArgs(None), want: False.ToObject()},
 		// Object

--- a/runtime/dict_test.go
+++ b/runtime/dict_test.go
@@ -24,7 +24,8 @@ import (
 
 // hashFoo is the hash of the string 'foo'. We use this to validate some corner
 // cases around hash collision below.
-var hashFoo = NewInt(-4177197833195190597).ToObject()
+// NOTE: Inline func helps support 32bit systems.
+var hashFoo = NewInt(func(i int64) int { return int(i) }(-4177197833195190597)).ToObject()
 
 func TestNewStringDict(t *testing.T) {
 	cases := []struct {

--- a/runtime/float_test.go
+++ b/runtime/float_test.go
@@ -119,7 +119,7 @@ func TestFloatCompare(t *testing.T) {
 
 func TestFloatInt(t *testing.T) {
 	cases := []invokeTestCase{
-		{args: wrapArgs(IntType, -3209539058.2), want: NewInt(-3209539058).ToObject()},
+		{args: wrapArgs(IntType, -1209539058.2), want: NewInt(-1209539058).ToObject()},
 		{args: wrapArgs(IntType, 2.994514758031654e+186), want: NewLong(func() *big.Int { i, _ := big.NewFloat(2.994514758031654e+186).Int(nil); return i }()).ToObject()},
 		{args: wrapArgs(IntType, math.Inf(1)), wantExc: mustCreateException(OverflowErrorType, "cannot convert float infinity to integer")},
 		{args: wrapArgs(IntType, math.Inf(-1)), wantExc: mustCreateException(OverflowErrorType, "cannot convert float infinity to integer")},

--- a/runtime/int_test.go
+++ b/runtime/int_test.go
@@ -59,7 +59,7 @@ func TestIntBinaryOps(t *testing.T) {
 		{Mod, NewInt(MinInt).ToObject(), NewInt(-1).ToObject(), NewLong(big.NewInt(0)).ToObject(), nil},
 		{Mul, NewInt(-1).ToObject(), NewInt(-3).ToObject(), NewInt(3).ToObject(), nil},
 		{Mul, newObject(ObjectType), NewInt(101).ToObject(), nil, mustCreateException(TypeErrorType, "unsupported operand type(s) for *: 'object' and 'int'")},
-		{Mul, NewInt(4294967295).ToObject(), NewInt(2147483649).ToObject(), NewLong(new(big.Int).Mul(big.NewInt(4294967295), big.NewInt(2147483649))).ToObject(), nil},
+		{Mul, NewInt(MaxInt).ToObject(), NewInt(MaxInt - 1).ToObject(), NewLong(new(big.Int).Mul(big.NewInt(MaxInt), big.NewInt(MaxInt-1))).ToObject(), nil},
 		{Or, NewInt(-100).ToObject(), NewInt(50).ToObject(), NewInt(-66).ToObject(), nil},
 		{Or, NewInt(MaxInt).ToObject(), NewInt(MinInt).ToObject(), NewInt(-1).ToObject(), nil},
 		{Or, newObject(ObjectType), NewInt(-100).ToObject(), nil, mustCreateException(TypeErrorType, "unsupported operand type(s) for |: 'object' and 'int'")},

--- a/runtime/long_test.go
+++ b/runtime/long_test.go
@@ -152,7 +152,7 @@ func TestLongBinaryOps(t *testing.T) {
 		{Mod, MinInt, 1, NewLong(big.NewInt(0)).ToObject(), nil},
 		{Mul, 1, 3, NewLong(big.NewInt(3)).ToObject(), nil},
 		{Mul, newObject(ObjectType), 101, nil, mustCreateException(TypeErrorType, "unsupported operand type(s) for *: 'object' and 'long'")},
-		{Mul, 4294967295, 2147483649, NewLong(new(big.Int).Mul(big.NewInt(4294967295), big.NewInt(2147483649))).ToObject(), nil},
+		{Mul, int64(4294967295), int64(2147483649), NewLong(new(big.Int).Mul(big.NewInt(4294967295), big.NewInt(2147483649))).ToObject(), nil},
 		{Or, -100, 50, NewLong(big.NewInt(-66)).ToObject(), nil},
 		{Or, MaxInt, MinInt, NewLong(big.NewInt(-1)).ToObject(), nil},
 		{Or, newObject(ObjectType), 100, nil, mustCreateException(TypeErrorType, "unsupported operand type(s) for |: 'object' and 'long'")},
@@ -168,23 +168,29 @@ func TestLongBinaryOps(t *testing.T) {
 		switch casv := cas.v.(type) {
 		case int:
 			v = NewLong(big.NewInt(int64(casv))).ToObject()
+		case int64:
+			v = NewLong(big.NewInt(casv)).ToObject()
 		case *big.Int:
 			v = NewLong(casv).ToObject()
 		case *Object:
 			v = casv
 		default:
-			panic("invalid test case")
+			t.Errorf("invalid test case: %T", casv)
+			continue
 		}
 		w := (*Object)(nil)
 		switch casw := cas.w.(type) {
 		case int:
 			w = NewLong(big.NewInt(int64(casw))).ToObject()
+		case int64:
+			w = NewLong(big.NewInt(casw)).ToObject()
 		case *big.Int:
 			w = NewLong(casw).ToObject()
 		case *Object:
 			w = casw
 		default:
-			panic("invalid test case")
+			t.Errorf("invalid test case: %T", casw)
+			continue
 		}
 		testCase := invokeTestCase{args: wrapArgs(v, w), want: cas.want, wantExc: cas.wantExc}
 		if err := runInvokeTestCase(wrapFuncForTest(cas.fun), &testCase); err != "" {

--- a/runtime/str_test.go
+++ b/runtime/str_test.go
@@ -29,6 +29,7 @@ func TestNewStr(t *testing.T) {
 	}
 }
 
+// # On a 64bit system:
 // >>> hash("foo")
 // -4177197833195190597
 // >>> hash("bar")
@@ -36,13 +37,14 @@ func TestNewStr(t *testing.T) {
 // >>> hash("baz")
 // 327024216814240876
 func TestHashString(t *testing.T) {
+	truncateInt := func(i int64) int { return int(i) } // Support for 32bit platforms
 	cases := []struct {
 		value string
 		hash  int
 	}{
-		{"foo", -4177197833195190597},
-		{"bar", 327024216814240868},
-		{"baz", 327024216814240876},
+		{"foo", truncateInt(-4177197833195190597)},
+		{"bar", truncateInt(327024216814240868)},
+		{"baz", truncateInt(327024216814240876)},
 	}
 	for _, cas := range cases {
 		if h := hashString(cas.value); h != cas.hash {

--- a/runtime/unicode_test.go
+++ b/runtime/unicode_test.go
@@ -142,10 +142,11 @@ func TestUnicodeGetItem(t *testing.T) {
 }
 
 func TestUnicodeHash(t *testing.T) {
+	truncateInt := func(i int64) int { return int(i) } // Support for 32bit systems.
 	cases := []invokeTestCase{
-		{args: wrapArgs(NewUnicode("foo")), want: NewInt(-4177197833195190597).ToObject()},
-		{args: wrapArgs(NewUnicode("bar")), want: NewInt(327024216814240868).ToObject()},
-		{args: wrapArgs(NewUnicode("baz")), want: NewInt(327024216814240876).ToObject()},
+		{args: wrapArgs(NewUnicode("foo")), want: NewInt(truncateInt(-4177197833195190597)).ToObject()},
+		{args: wrapArgs(NewUnicode("bar")), want: NewInt(truncateInt(327024216814240868)).ToObject()},
+		{args: wrapArgs(NewUnicode("baz")), want: NewInt(truncateInt(327024216814240876)).ToObject()},
 		{args: wrapArgs(NewUnicode("")), want: NewInt(0).ToObject()},
 	}
 	for _, cas := range cases {


### PR DESCRIPTION
I tried to preserve intent in the constants, but it might be worth double checking I didn't break anything along the way.