### PR TITLE
Don't trigger segfaults/panics when producing a string from an Object.

### DIFF
--- a/runtime/object.go
+++ b/runtime/object.go
@@ -71,6 +71,9 @@ func (o *Object) Dict() *Dict {
 
 // String returns a string representation of o, e.g. for debugging.
 func (o *Object) String() string {
+	if o == nil {
+		return "nil"
+	}
 	s, raised := Repr(newFrame(nil), o)
 	if raised != nil {
 		return fmt.Sprintf("<%s object (repr raised %s)>", o.typ.Name(), raised.typ.Name())


### PR DESCRIPTION
While trying to debug an issue in the native support, I was running with GDB, and kept getting hit with segfaults when (*Object)(nil)s were getting String() called on them (buried deep in a call to fmt.SomethingOrOther). This seems like a sensible return value in this case. I could also see arguing that this shouldn't happen, and the source should be addressed. I didn't get a stack trace when I ran into this, bit it shouldn't be too hard if we would rather go that route.