### PR TITLE
Add abs() for int, float and long.

### DIFF
--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -183,6 +183,20 @@ func initBuiltinType(typ *Type, info *builtinTypeInfo) {
 	}
 }
 
+func builtinAbs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+	if raised := checkFunctionArgs(f, "abs", args, ObjectType); raised != nil {
+		return nil, raised
+	}
+
+	if method, raised := args[0].typ.mroLookup(f, NewStr("__abs__")); raised != nil {
+		return nil, raised
+	} else if method != nil {
+		return method.Call(f, args, nil)
+	}
+
+	return NewInt(0).ToObject(), nil
+}
+
 func builtinBin(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "bin", args, ObjectType); raised != nil {
 		return nil, raised
@@ -464,6 +478,7 @@ func builtinUniChr(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 func init() {
 	builtinMap := map[string]*Object{
 		"__frame__":      newBuiltinFunction("__frame__", builtinFrame).ToObject(),
+		"abs":            newBuiltinFunction("abs", builtinAbs).ToObject(),
 		"bin":            newBuiltinFunction("bin", builtinBin).ToObject(),
 		"chr":            newBuiltinFunction("chr", builtinChr).ToObject(),
 		"dir":            newBuiltinFunction("dir", builtinDir).ToObject(),

--- a/runtime/float.go
+++ b/runtime/float.go
@@ -50,6 +50,10 @@ func (f *Float) Value() float64 {
 	return f.value
 }
 
+func floatAbs(f *Frame, v *Object) (*Object, *BaseException) {
+	return NewFloat(math.Abs(float64(toFloatUnsafe(v).Value()))).ToObject(), nil
+}
+
 func floatAdd(f *Frame, v, w *Object) (*Object, *BaseException) {
 	return floatArithmeticOp(f, "__add__", v, w, func(v, w float64) float64 { return v + w })
 }
@@ -221,6 +225,7 @@ func floatSub(f *Frame, v, w *Object) (*Object, *BaseException) {
 
 func initFloatType(dict map[string]*Object) {
 	dict["__getnewargs__"] = newBuiltinFunction("__getnewargs__", floatGetNewArgs).ToObject()
+	FloatType.slots.Abs = &unaryOpSlot{floatAbs}
 	FloatType.slots.Add = &binaryOpSlot{floatAdd}
 	FloatType.slots.Div = &binaryOpSlot{floatDiv}
 	FloatType.slots.Eq = &binaryOpSlot{floatEq}

--- a/runtime/float_test.go
+++ b/runtime/float_test.go
@@ -238,3 +238,16 @@ func TestFloatStrRepr(t *testing.T) {
 		}
 	}
 }
+
+func TestFloatAbs(t *testing.T) {
+	cases := []invokeTestCase{
+		{args: wrapArgs(-42.42), want: NewFloat(42.42).ToObject()},
+		{args: wrapArgs(0.0), want: NewFloat(0.0).ToObject()},
+		{args: wrapArgs(42.42), want: NewFloat(42.42).ToObject()},
+	}
+	for _, c := range cases {
+		if err := runInvokeMethodTestCase(FloatType, "__abs__", &c); err != "" {
+			t.Error(err)
+		}
+	}
+}

--- a/runtime/int.go
+++ b/runtime/int.go
@@ -16,6 +16,7 @@ package grumpy
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -65,6 +66,10 @@ func (i *Int) IsTrue() bool {
 
 // IntType is the object representing the Python 'int' type.
 var IntType = newBasisType("int", reflect.TypeOf(Int{}), toIntUnsafe, ObjectType)
+
+func intAbs(f *Frame, v *Object) (*Object, *BaseException) {
+	return NewInt(int(math.Abs(float64(toIntUnsafe(v).Value())))).ToObject(), nil
+}
 
 func intAdd(f *Frame, v, w *Object) (*Object, *BaseException) {
 	return intAddMulOp(f, "__add__", v, w, intCheckedAdd, longAdd)
@@ -287,6 +292,7 @@ func intXor(f *Frame, v, w *Object) (*Object, *BaseException) {
 
 func initIntType(dict map[string]*Object) {
 	dict["__getnewargs__"] = newBuiltinFunction("__getnewargs__", intGetNewArgs).ToObject()
+	IntType.slots.Abs = &unaryOpSlot{intAbs}
 	IntType.slots.Add = &binaryOpSlot{intAdd}
 	IntType.slots.And = &binaryOpSlot{intAnd}
 	IntType.slots.Div = &binaryOpSlot{intDiv}

--- a/runtime/int_test.go
+++ b/runtime/int_test.go
@@ -92,6 +92,24 @@ func TestIntCompare(t *testing.T) {
 	}
 }
 
+func TestIntAbs(t *testing.T) {
+	cases := []invokeTestCase{
+		{args: wrapArgs(-42), want: NewInt(42).ToObject()},
+		{args: wrapArgs(0), want: NewInt(0).ToObject()},
+		{args: wrapArgs(42), want: NewInt(42).ToObject()},
+		// TODO(dhananjay92): Figure out a way to handle max-min ints safely.
+		// Currently, MaxInt overflows int type on some platforms.
+		// https://play.golang.org/p/ukNGfPjpAT has the smaller repro case.
+		// It overflows on linux/amd64, but works fine on playground.
+		// {args: wrapArgs(MaxInt), want: NewInt(MaxInt).ToObject()},
+	}
+	for _, c := range cases {
+		if err := runInvokeMethodTestCase(IntType, "__abs__", &c); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
 func TestIntInvert(t *testing.T) {
 	cases := []invokeTestCase{
 		{args: wrapArgs(2592), want: NewInt(-2593).ToObject()},

--- a/runtime/long.go
+++ b/runtime/long.go
@@ -86,6 +86,10 @@ func (l *Long) Neg() *Long {
 // LongType is the object representing the Python 'long' type.
 var LongType = newBasisType("long", reflect.TypeOf(Long{}), toLongUnsafe, ObjectType)
 
+func longAbs(z, x *big.Int) {
+	z.Abs(x)
+}
+
 func longAdd(z, x, y *big.Int) {
 	z.Add(x, y)
 }
@@ -299,6 +303,7 @@ func longXor(z, x, y *big.Int) {
 
 func initLongType(dict map[string]*Object) {
 	dict["__getnewargs__"] = newBuiltinFunction("__getnewargs__", longGetNewArgs).ToObject()
+	LongType.slots.Abs = longUnaryOpSlot(longAbs)
 	LongType.slots.Add = longBinaryOpSlot(longAdd)
 	LongType.slots.And = longBinaryOpSlot(longAnd)
 	LongType.slots.Div = longDivModOpSlot(longDiv)

--- a/runtime/long_test.go
+++ b/runtime/long_test.go
@@ -227,6 +227,19 @@ func TestLongCompare(t *testing.T) {
 	}
 }
 
+func TestLongAbs(t *testing.T) {
+	cases := []invokeTestCase{
+		{args: wrapArgs(big.NewInt(42)), want: NewLong(big.NewInt(42)).ToObject()},
+		{args: wrapArgs(big.NewInt(0)), want: NewLong(big.NewInt(0)).ToObject()},
+		{args: wrapArgs(big.NewInt(-42)), want: NewLong(big.NewInt(42)).ToObject()},
+	}
+	for _, cas := range cases {
+		if err := runInvokeMethodTestCase(LongType, "__abs__", &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
 func TestLongInvert(t *testing.T) {
 	googol, _ := big.NewFloat(1e100).Int(nil)
 	cases := []invokeTestCase{

--- a/runtime/slots.go
+++ b/runtime/slots.go
@@ -369,6 +369,7 @@ func (s *unaryOpSlot) wrapCallable(callable *Object) bool {
 // The wrapper structs permit comparison of like slots which is occasionally
 // necessary to determine whether a function has been overridden by a subclass.
 type typeSlots struct {
+	Abs          *unaryOpSlot
 	Add          *binaryOpSlot
 	And          *binaryOpSlot
 	Basis        *basisSlot


### PR DESCRIPTION
For bool, it's already supported. This produces,
```
$ cat build/src/haha/haha.py 
# int
haha = -42
print dir(haha)
print abs(haha)

print abs(9223372036854775807)

# float
hihi = -10.546
print dir(hihi)
print abs(hihi)

# bool
hehe = True
print dir(hehe)
print abs(hehe)

# long
huhu = long(-42)
print dir(huhu)
print abs(huhu)

$ go build haha

$ ./haha 
['__abs__', '__add__', '__and__', '__class__', '__delattr__', '__dict__', '__div__', '__eq__', '__float__', '__ge__', '__getattribute__', '__getnewargs__', '__gt__', '__hash__', '__index__', '__int__', '__invert__', '__le__', '__long__', '__lshift__', '__lt__', '__mod__', '__module__', '__mul__', '__ne__', '__new__', '__nonzero__', '__or__', '__radd__', '__rand__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rlshift__', '__rmod__', '__rmul__', '__ror__', '__rrshift__', '__rshift__', '__rsub__', '__rxor__', '__setattr__', '__sub__', '__xor__']
42
-9223372036854775808
['__abs__', '__add__', '__class__', '__delattr__', '__dict__', '__div__', '__eq__', '__float__', '__ge__', '__getattribute__', '__getnewargs__', '__gt__', '__hash__', '__int__', '__le__', '__long__', '__lt__', '__mod__', '__module__', '__mul__', '__ne__', '__new__', '__nonzero__', '__radd__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rmod__', '__rmul__', '__rsub__', '__setattr__', '__sub__']
10.546
['__abs__', '__add__', '__and__', '__class__', '__delattr__', '__dict__', '__div__', '__eq__', '__float__', '__ge__', '__getattribute__', '__getnewargs__', '__gt__', '__hash__', '__index__', '__int__', '__invert__', '__le__', '__long__', '__lshift__', '__lt__', '__mod__', '__module__', '__mul__', '__ne__', '__new__', '__nonzero__', '__or__', '__radd__', '__rand__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rlshift__', '__rmod__', '__rmul__', '__ror__', '__rrshift__', '__rshift__', '__rsub__', '__rxor__', '__setattr__', '__sub__', '__xor__']
1
['__abs__', '__add__', '__and__', '__class__', '__delattr__', '__dict__', '__div__', '__eq__', '__float__', '__ge__', '__getattribute__', '__getnewargs__', '__gt__', '__hash__', '__index__', '__int__', '__invert__', '__le__', '__long__', '__lshift__', '__lt__', '__mod__', '__module__', '__mul__', '__ne__', '__new__', '__nonzero__', '__or__', '__radd__', '__rand__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rlshift__', '__rmod__', '__rmul__', '__ror__', '__rrshift__', '__rshift__', '__rsub__', '__rxor__', '__setattr__', '__str__', '__sub__', '__xor__']
42
```

`TestFoo` fails but it is failing on master too.

**Known limitation**: `abs(MaxInt)` overflows on some platform because in Go, `int(veryLargeFloat64)` [overflows](https://play.golang.org/p/ukNGfPjpAT). I've a todo for myself to figure out a safe way to handle them. Hopefully we can figure it out during code-review.

