### PR TITLE
unsafe: Removes most of the `unsafe` casts.

### DIFF
--- a/runtime/baseexception.go
+++ b/runtime/baseexception.go
@@ -25,7 +25,7 @@ type BaseException struct {
 }
 
 func toBaseExceptionUnsafe(o *Object) *BaseException {
-	return (*BaseException)(o.toPointer())
+	return o.self.(*BaseException)
 }
 
 // ToObject upcasts e to an Object.

--- a/runtime/bool.go
+++ b/runtime/bool.go
@@ -69,3 +69,8 @@ var (
 	trueStr  = NewStr("True").ToObject()
 	falseStr = NewStr("False").ToObject()
 )
+
+func init() {
+	False.self = False
+	True.self = True
+}

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -17,6 +17,7 @@ package grumpy
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 	"unicode"
 )
 
@@ -325,7 +326,7 @@ func builtinID(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "id", args, ObjectType); raised != nil {
 		return nil, raised
 	}
-	return NewInt(int(uintptr(args[0].toPointer()))).ToObject(), nil
+	return NewInt(int(reflect.ValueOf(args[0]).Pointer())).ToObject(), nil
 }
 
 func builtinIsInstance(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -17,6 +17,7 @@ package grumpy
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 )
 
@@ -102,7 +103,7 @@ func TestBuiltinFuncs(t *testing.T) {
 		{f: "hex", args: wrapArgs(0.1), wantExc: mustCreateException(TypeErrorType, "hex() argument can't be converted to hex")},
 		{f: "hex", args: wrapArgs(1, 2, 3), wantExc: mustCreateException(TypeErrorType, "'hex' requires 1 arguments")},
 		{f: "hex", args: wrapArgs(newObject(hexOctType)), want: NewStr("0xhexadecimal").ToObject()},
-		{f: "id", args: wrapArgs(foo), want: NewInt(int(uintptr(foo.toPointer()))).ToObject()},
+		{f: "id", args: wrapArgs(foo), want: NewInt(int(reflect.ValueOf(foo).Pointer())).ToObject()},
 		{f: "id", args: wrapArgs(), wantExc: mustCreateException(TypeErrorType, "'id' requires 1 arguments")},
 		{f: "isinstance", args: wrapArgs(NewInt(42).ToObject(), IntType.ToObject()), want: True.ToObject()},
 		{f: "isinstance", args: wrapArgs(NewStr("foo").ToObject(), TupleType.ToObject()), want: False.ToObject()},

--- a/runtime/code.go
+++ b/runtime/code.go
@@ -47,6 +47,8 @@ type Code struct {
 	fn      func(*Frame, []*Object) (*Object, *BaseException)
 }
 
+func (c *Code) ToObject() *Object { return &c.Object }
+
 // NewCode creates a new Code object that executes the given fn.
 func NewCode(name, filename string, args []FunctionArg, flags CodeFlag, fn func(*Frame, []*Object) (*Object, *BaseException)) *Code {
 	argc := len(args)
@@ -62,11 +64,13 @@ func NewCode(name, filename string, args []FunctionArg, flags CodeFlag, fn func(
 			logFatal(fmt.Sprintf(format, name, arg.Name))
 		}
 	}
-	return &Code{Object{typ: CodeType}, name, filename, argc, minArgc, flags, args, fn}
+	c := &Code{Object{typ: CodeType}, name, filename, argc, minArgc, flags, args, fn}
+	c.self = c
+	return c
 }
 
 func toCodeUnsafe(o *Object) *Code {
-	return (*Code)(o.toPointer())
+	return o.self.(*Code)
 }
 
 // Eval runs the code object c in the context of the given globals.

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -914,7 +914,7 @@ func compareRich(f *Frame, op compareOp, v, w *Object) (*Object, *BaseException)
 // closely resembles the behavior of CPython's default_3way_compare in object.c.
 func compareDefault(f *Frame, v, w *Object) int {
 	if v.typ == w.typ {
-		pv, pw := uintptr(v.toPointer()), uintptr(w.toPointer())
+		pv, pw := reflect.ValueOf(v).Pointer(), reflect.ValueOf(w).Pointer()
 		if pv < pw {
 			return -1
 		}
@@ -938,7 +938,7 @@ func compareDefault(f *Frame, v, w *Object) int {
 	if v.typ.Name() != w.typ.Name() {
 		return 1
 	}
-	if uintptr(v.typ.toPointer()) < uintptr(w.typ.toPointer()) {
+	if reflect.ValueOf(v.typ).Pointer() < reflect.ValueOf(w.typ).Pointer() {
 		return -1
 	}
 	return 1

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -157,14 +157,14 @@ func TestBinaryOps(t *testing.T) {
 func TestCompareDefault(t *testing.T) {
 	o1, o2 := newObject(ObjectType), newObject(ObjectType)
 	// Make sure uintptr(o1) < uintptr(o2).
-	if uintptr(o1.toPointer()) > uintptr(o2.toPointer()) {
+	if reflect.ValueOf(o1).Pointer() > reflect.ValueOf(o2).Pointer() {
 		o1, o2 = o2, o1
 	}
 	// When type names are equal, comparison should fall back to comparing
 	// the pointer values of the types of the objects.
 	fakeObjectType := newTestClass("object", []*Type{ObjectType}, NewDict())
 	o3, o4 := newObject(fakeObjectType), newObject(ObjectType)
-	if uintptr(o3.typ.toPointer()) > uintptr(o4.typ.toPointer()) {
+	if reflect.ValueOf(o3.typ).Pointer() > reflect.ValueOf(o4.typ).Pointer() {
 		o3, o4 = o4, o3
 	}
 	// An int subtype that equals anything, but doesn't override other
@@ -331,7 +331,7 @@ func TestHash(t *testing.T) {
 	cases := []invokeTestCase{
 		{args: wrapArgs("foo"), want: hashFoo},
 		{args: wrapArgs(123), want: NewInt(123).ToObject()},
-		{args: wrapArgs(o), want: NewInt(int(uintptr(o.toPointer()))).ToObject()},
+		{args: wrapArgs(o), want: NewInt(int(reflect.ValueOf(o).Pointer())).ToObject()},
 		{args: wrapArgs(NewList()), wantExc: mustCreateException(TypeErrorType, "unhashable type: 'list'")},
 		{args: wrapArgs(NewDict()), wantExc: mustCreateException(TypeErrorType, "unhashable type: 'dict'")},
 		{args: wrapArgs(newObject(badHash)), wantExc: mustCreateException(TypeErrorType, "an integer is required")},

--- a/runtime/descriptor.go
+++ b/runtime/descriptor.go
@@ -26,11 +26,13 @@ type Property struct {
 }
 
 func newProperty(get, set, del *Object) *Property {
-	return &Property{Object{typ: PropertyType}, get, set, del}
+	p := &Property{Object{typ: PropertyType}, get, set, del}
+	p.self = p
+	return p
 }
 
 func toPropertyUnsafe(o *Object) *Property {
-	return (*Property)(o.toPointer())
+	return o.self.(*Property)
 }
 
 // ToObject upcasts p to an Object.

--- a/runtime/dict.go
+++ b/runtime/dict.go
@@ -266,7 +266,9 @@ type Dict struct {
 
 // NewDict returns an empty Dict.
 func NewDict() *Dict {
-	return &Dict{Object: Object{typ: DictType}, table: newDictTable(0)}
+	d := &Dict{Object: Object{typ: DictType}, table: newDictTable(0)}
+	d.self = d
+	return d
 }
 
 func newStringDict(items map[string]*Object) *Dict {
@@ -278,11 +280,13 @@ func newStringDict(items map[string]*Object) *Dict {
 	for key, value := range items {
 		table.insertAbsentEntry(&dictEntry{hashString(key), NewStr(key).ToObject(), value})
 	}
-	return &Dict{Object: Object{typ: DictType}, table: table}
+	d := &Dict{Object: Object{typ: DictType}, table: table}
+	d.self = d
+	return d
 }
 
 func toDictUnsafe(o *Object) *Dict {
-	return (*Dict)(o.toPointer())
+	return o.self.(*Dict)
 }
 
 // loadTable atomically loads and returns d's underlying dictTable.
@@ -741,15 +745,17 @@ type dictItemIterator struct {
 // newDictItemIterator creates a dictItemIterator object for d. It assumes that
 // d.mutex is held by the caller.
 func newDictItemIterator(d *Dict) *dictItemIterator {
-	return &dictItemIterator{
+	i := &dictItemIterator{
 		Object: Object{typ: dictItemIteratorType},
 		iter:   newDictEntryIterator(d),
 		guard:  newDictVersionGuard(d),
 	}
+	i.self = i
+	return i
 }
 
 func toDictItemIteratorUnsafe(o *Object) *dictItemIterator {
-	return (*dictItemIterator)(o.toPointer())
+	return o.self.(*dictItemIterator)
 }
 
 func (iter *dictItemIterator) ToObject() *Object {
@@ -784,15 +790,17 @@ type dictKeyIterator struct {
 // newDictKeyIterator creates a dictKeyIterator object for d. It assumes that
 // d.mutex is held by the caller.
 func newDictKeyIterator(d *Dict) *dictKeyIterator {
-	return &dictKeyIterator{
+	i := &dictKeyIterator{
 		Object: Object{typ: dictKeyIteratorType},
 		iter:   newDictEntryIterator(d),
 		guard:  newDictVersionGuard(d),
 	}
+	i.self = i
+	return i
 }
 
 func toDictKeyIteratorUnsafe(o *Object) *dictKeyIterator {
-	return (*dictKeyIterator)(o.toPointer())
+	return o.self.(*dictKeyIterator)
 }
 
 func (iter *dictKeyIterator) ToObject() *Object {

--- a/runtime/file.go
+++ b/runtime/file.go
@@ -45,12 +45,13 @@ type File struct {
 func NewFileFromFD(fd uintptr) *File {
 	// TODO: Use fcntl or something to get the mode of the descriptor.
 	file := &File{Object: Object{typ: FileType}, mode: "?", open: true, file: os.NewFile(fd, "<fdopen>")}
+	file.self = file
 	file.reader = bufio.NewReader(file.file)
 	return file
 }
 
 func toFileUnsafe(o *Object) *File {
-	return (*File)(o.toPointer())
+	return o.self.(*File)
 }
 
 // ToObject upcasts f to an Object.

--- a/runtime/float.go
+++ b/runtime/float.go
@@ -33,11 +33,13 @@ type Float struct {
 
 // NewFloat returns a new Float holding the given floating point value.
 func NewFloat(value float64) *Float {
-	return &Float{Object{typ: FloatType}, value}
+	f := &Float{Object{typ: FloatType}, value}
+	f.self = f
+	return f
 }
 
 func toFloatUnsafe(o *Object) *Float {
-	return (*Float)(o.toPointer())
+	return o.self.(*Float)
 }
 
 // ToObject upcasts f to an Object.

--- a/runtime/float_test.go
+++ b/runtime/float_test.go
@@ -161,10 +161,14 @@ func TestFloatIsTrue(t *testing.T) {
 }
 
 func TestFloatNew(t *testing.T) {
+	setFloatSelf := func(f *Float) *Float {
+		f.self = f
+		return f
+	}
 	floatNew := mustNotRaise(GetAttr(NewRootFrame(), FloatType.ToObject(), NewStr("__new__"), nil))
 	strictEqType := newTestClassStrictEq("StrictEq", FloatType)
 	subType := newTestClass("SubType", []*Type{FloatType}, newStringDict(map[string]*Object{}))
-	subTypeObject := (&Float{Object: Object{typ: subType}, value: 3.14}).ToObject()
+	subTypeObject := setFloatSelf(&Float{Object: Object{typ: subType}, value: 3.14}).ToObject()
 	goodSlotType := newTestClass("GoodSlot", []*Type{ObjectType}, newStringDict(map[string]*Object{
 		"__float__": newBuiltinFunction("__float__", func(_ *Frame, _ Args, _ KWArgs) (*Object, *BaseException) {
 			return NewFloat(3.14).ToObject(), nil
@@ -199,8 +203,8 @@ func TestFloatNew(t *testing.T) {
 		{args: wrapArgs(FloatType, newObject(goodSlotType)), want: NewFloat(3.14).ToObject()},
 		{args: wrapArgs(FloatType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__float__ returned non-float (type object)")},
 		{args: wrapArgs(FloatType, newObject(slotSubTypeType)), want: subTypeObject},
-		{args: wrapArgs(strictEqType, 3.14), want: (&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
-		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: (&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
+		{args: wrapArgs(strictEqType, 3.14), want: setFloatSelf(&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
+		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: setFloatSelf(&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
 		{args: wrapArgs(strictEqType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__float__ returned non-float (type object)")},
 		{args: wrapArgs(), wantExc: mustCreateException(TypeErrorType, "'__new__' requires 1 arguments")},
 		{args: wrapArgs(IntType), wantExc: mustCreateException(TypeErrorType, "float.__new__(int): int is not a subtype of float")},

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -49,6 +49,7 @@ func NewRootFrame() *Frame {
 // newFrame creates a new Frame whose parent frame is back.
 func newFrame(back *Frame) *Frame {
 	f := &Frame{Object: Object{typ: FrameType}}
+	f.self = f
 	f.pushFrame(back)
 	return f
 }
@@ -64,7 +65,7 @@ func (f *Frame) pushFrame(back *Frame) {
 }
 
 func toFrameUnsafe(o *Object) *Frame {
-	return (*Frame)(o.toPointer())
+	return o.self.(*Frame)
 }
 
 // Globals returns the globals dict for this frame.

--- a/runtime/function.go
+++ b/runtime/function.go
@@ -95,17 +95,21 @@ type FunctionArg struct {
 // number of arguments are provided, populating *args and **kwargs if
 // necessary, etc.
 func NewFunction(c *Code, globals *Dict) *Function {
-	return &Function{Object{typ: FunctionType, dict: NewDict()}, nil, c.name, c, globals}
+	f := &Function{Object{typ: FunctionType, dict: NewDict()}, nil, c.name, c, globals}
+	f.self = f
+	return f
 }
 
 // newBuiltinFunction returns a function object with the given name that
 // invokes fn when called.
 func newBuiltinFunction(name string, fn Func) *Function {
-	return &Function{Object: Object{typ: FunctionType, dict: NewDict()}, fn: fn, name: name}
+	f := &Function{Object: Object{typ: FunctionType, dict: NewDict()}, fn: fn, name: name}
+	f.self = f
+	return f
 }
 
 func toFunctionUnsafe(o *Object) *Function {
-	return (*Function)(o.toPointer())
+	return o.self.(*Function)
 }
 
 // ToObject upcasts f to an Object.
@@ -150,11 +154,13 @@ type staticMethod struct {
 }
 
 func newStaticMethod(callable *Object) *staticMethod {
-	return &staticMethod{Object{typ: StaticMethodType}, callable}
+	s := &staticMethod{Object{typ: StaticMethodType}, callable}
+	s.self = s
+	return s
 }
 
 func toStaticMethodUnsafe(o *Object) *staticMethod {
-	return (*staticMethod)(o.toPointer())
+	return o.self.(*staticMethod)
 }
 
 // ToObject upcasts f to an Object.

--- a/runtime/generator.go
+++ b/runtime/generator.go
@@ -44,11 +44,13 @@ type Generator struct {
 
 // NewGenerator returns a new Generator object that runs the given Block b.
 func NewGenerator(f *Frame, fn func(*Object) (*Object, *BaseException)) *Generator {
-	return &Generator{Object: Object{typ: GeneratorType}, frame: f, fn: fn}
+	g := &Generator{Object: Object{typ: GeneratorType}, frame: f, fn: fn}
+	g.self = g
+	return g
 }
 
 func toGeneratorUnsafe(o *Object) *Generator {
-	return (*Generator)(o.toPointer())
+	return o.self.(*Generator)
 }
 
 func (g *Generator) resume(f *Frame, sendValue *Object) (*Object, *BaseException) {

--- a/runtime/int.go
+++ b/runtime/int.go
@@ -26,9 +26,13 @@ const (
 	internedIntMax = 300
 )
 
-var (
-	internedInts = makeInternedInts()
-)
+var internedInts [internedIntMax - internedIntMin + 1]Int
+
+func init() {
+	for i := internedIntMin; i <= internedIntMax; i++ {
+		internedInts[i-internedIntMin] = Int{Object{typ: IntType, self: &internedInts[i-internedIntMin]}, i}
+	}
+}
 
 // Int represents Python 'int' objects.
 type Int struct {
@@ -41,11 +45,13 @@ func NewInt(value int) *Int {
 	if value >= internedIntMin && value <= internedIntMax {
 		return &internedInts[value-internedIntMin]
 	}
-	return &Int{Object{typ: IntType}, value}
+	i := &Int{Object{typ: IntType}, value}
+	i.self = i
+	return i
 }
 
 func toIntUnsafe(o *Object) *Int {
-	return (*Int)(o.toPointer())
+	return o.self.(*Int)
 }
 
 // ToObject upcasts i to an Object.
@@ -503,12 +509,4 @@ func intFromObject(f *Frame, o *Object) (*Object, *BaseException) {
 
 func intToLong(o *Int) *Long {
 	return NewLong(big.NewInt(int64(o.Value())))
-}
-
-func makeInternedInts() [internedIntMax - internedIntMin + 1]Int {
-	var ints [internedIntMax - internedIntMin + 1]Int
-	for i := internedIntMin; i <= internedIntMax; i++ {
-		ints[i-internedIntMin] = Int{Object{typ: IntType}, i}
-	}
-	return ints
 }

--- a/runtime/int_test.go
+++ b/runtime/int_test.go
@@ -113,9 +113,13 @@ func TestIntNew(t *testing.T) {
 			return args[0], nil
 		}).ToObject(),
 	}))
+	setIntSelf := func(i *Int) *Int {
+		i.self = i
+		return i
+	}
 	strictEqType := newTestClassStrictEq("StrictEq", IntType)
 	subType := newTestClass("SubType", []*Type{IntType}, newStringDict(map[string]*Object{}))
-	subTypeObject := (&Int{Object: Object{typ: subType}, value: 3}).ToObject()
+	subTypeObject := setIntSelf(&Int{Object: Object{typ: subType}, value: 3}).ToObject()
 	goodSlotType := newTestClass("GoodSlot", []*Type{ObjectType}, newStringDict(map[string]*Object{
 		"__int__": newBuiltinFunction("__int__", func(_ *Frame, _ Args, _ KWArgs) (*Object, *BaseException) {
 			return NewInt(3).ToObject(), nil
@@ -145,11 +149,11 @@ func TestIntNew(t *testing.T) {
 		{args: wrapArgs(IntType, "102", 0), want: NewInt(102).ToObject()},
 		{args: wrapArgs(IntType, 42), want: NewInt(42).ToObject()},
 		{args: wrapArgs(IntType, -3.14), want: NewInt(-3).ToObject()},
-		{args: wrapArgs(strictEqType, 42), want: (&Int{Object{typ: strictEqType}, 42}).ToObject()},
+		{args: wrapArgs(strictEqType, 42), want: setIntSelf(&Int{Object{typ: strictEqType}, 42}).ToObject()},
 		{args: wrapArgs(IntType, newObject(goodSlotType)), want: NewInt(3).ToObject()},
 		{args: wrapArgs(IntType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__int__ returned non-int (type object)")},
 		{args: wrapArgs(IntType, newObject(slotSubTypeType)), want: subTypeObject},
-		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: (&Int{Object{typ: strictEqType}, 3}).ToObject()},
+		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: setIntSelf(&Int{Object{typ: strictEqType}, 3}).ToObject()},
 		{args: wrapArgs(strictEqType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__int__ returned non-int (type object)")},
 		{args: wrapArgs(IntType, "0xff"), wantExc: mustCreateException(ValueErrorType, "invalid literal for int() with base 10: 0xff")},
 		{args: wrapArgs(IntType, ""), wantExc: mustCreateException(ValueErrorType, "invalid literal for int() with base 10: ")},

--- a/runtime/list.go
+++ b/runtime/list.go
@@ -35,6 +35,7 @@ type List struct {
 // NewList returns a list containing the given elements.
 func NewList(elems ...*Object) *List {
 	l := &List{Object: Object{typ: ListType}}
+	l.self = l
 	numElems := len(elems)
 	l.resize(numElems)
 	for i := 0; i < numElems; i++ {
@@ -44,7 +45,7 @@ func NewList(elems ...*Object) *List {
 }
 
 func toListUnsafe(o *Object) *List {
-	return (*List)(o.toPointer())
+	return o.self.(*List)
 }
 
 // ToObject upcasts l to an Object.
@@ -368,11 +369,12 @@ type listIterator struct {
 
 func newListIterator(l *List) *Object {
 	iter := &listIterator{Object: Object{typ: listIteratorType}, list: l}
+	iter.self = iter
 	return &iter.Object
 }
 
 func toListIteratorUnsafe(o *Object) *listIterator {
-	return (*listIterator)(o.toPointer())
+	return o.self.(*listIterator)
 }
 
 var listIteratorType = newBasisType("listiterator", reflect.TypeOf(listIterator{}), toListIteratorUnsafe, ObjectType)

--- a/runtime/long.go
+++ b/runtime/long.go
@@ -43,21 +43,23 @@ type Long struct {
 
 // NewLong returns a new Long holding the given value.
 func NewLong(x *big.Int) *Long {
-	result := Long{Object: Object{typ: LongType}}
+	result := &Long{Object: Object{typ: LongType}}
+	result.self = result
 	result.value.Set(x)
-	return &result
+	return result
 }
 
 // NewLongFromBytes returns a new Long holding the given bytes,
 // interpreted as a big endian unsigned integer.
 func NewLongFromBytes(b []byte) *Long {
-	result := Long{Object: Object{typ: LongType}}
+	result := &Long{Object: Object{typ: LongType}}
+	result.self = result
 	result.value.SetBytes(b)
-	return &result
+	return result
 }
 
 func toLongUnsafe(o *Object) *Long {
-	return (*Long)(o.toPointer())
+	return o.self.(*Long)
 }
 
 // ToObject upcasts l to an Object.
@@ -77,10 +79,11 @@ func (l *Long) IsTrue() bool {
 
 // Neg returns a new Long that is the negative of l.
 func (l *Long) Neg() *Long {
-	result := Long{Object: Object{typ: LongType}}
+	result := &Long{Object: Object{typ: LongType}}
+	result.self = result
 	result.value.Set(&l.value)
 	result.value.Neg(&result.value)
-	return &result
+	return result
 }
 
 // LongType is the object representing the Python 'long' type.
@@ -174,7 +177,8 @@ func longLong(f *Frame, o *Object) (*Object, *BaseException) {
 	if o.typ == LongType {
 		return o, nil
 	}
-	l := Long{Object: Object{typ: LongType}}
+	l := &Long{Object: Object{typ: LongType}}
+	l.self = l
 	l.value.Set(&toLongUnsafe(o).value)
 	return l.ToObject(), nil
 }
@@ -344,7 +348,8 @@ func initLongType(dict map[string]*Object) {
 }
 
 func longCallUnary(fun func(z, x *big.Int), v *Long) *Object {
-	l := Long{Object: Object{typ: LongType}}
+	l := &Long{Object: Object{typ: LongType}}
+	l.self = l
 	fun(&l.value, &v.value)
 	return l.ToObject()
 }
@@ -354,7 +359,8 @@ func longCallUnaryBool(fun func(x *big.Int) bool, v *Long) *Object {
 }
 
 func longCallBinary(fun func(z, x, y *big.Int), v, w *Long) *Object {
-	l := Long{Object: Object{typ: LongType}}
+	l := &Long{Object: Object{typ: LongType}}
+	l.self = l
 	fun(&l.value, &v.value, &w.value)
 	return l.ToObject()
 }
@@ -370,7 +376,8 @@ func longCallShift(fun func(z, x *big.Int, n uint), f *Frame, v, w *Long) (*Obje
 	if w.value.Sign() < 0 {
 		return nil, f.RaiseType(ValueErrorType, "negative shift count")
 	}
-	l := Long{Object: Object{typ: LongType}}
+	l := &Long{Object: Object{typ: LongType}}
+	l.self = l
 	fun(&l.value, &v.value, uint(w.value.Int64()))
 	return l.ToObject(), nil
 }

--- a/runtime/long_test.go
+++ b/runtime/long_test.go
@@ -67,7 +67,8 @@ func TestLongNew(t *testing.T) {
 	}))
 	strictEqType := newTestClassStrictEq("StrictEq", LongType)
 	newStrictEq := func(i *big.Int) *Object {
-		l := Long{Object: Object{typ: strictEqType}}
+		l := &Long{Object: Object{typ: strictEqType}}
+		l.self = l
 		l.value.Set(i)
 		return l.ToObject()
 	}

--- a/runtime/method.go
+++ b/runtime/method.go
@@ -31,11 +31,13 @@ type Method struct {
 // NewMethod returns a method wrapping the given function belonging to class.
 // When self is None the method is unbound, otherwise it is bound to self.
 func NewMethod(function *Function, self *Object, class *Type) *Method {
-	return &Method{Object{typ: MethodType}, function, self, class, function.Name()}
+	m := &Method{Object{typ: MethodType}, function, self, class, function.Name()}
+	m.Object.self = m
+	return m
 }
 
 func toMethodUnsafe(o *Object) *Method {
-	return (*Method)(o.toPointer())
+	return o.self.(*Method)
 }
 
 // ToObject upcasts m to an Object.

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -186,11 +186,13 @@ func newModule(name, filename string) *Module {
 		"__file__": NewStr(filename).ToObject(),
 		"__name__": NewStr(name).ToObject(),
 	})
-	return &Module{Object: Object{typ: ModuleType, dict: d}}
+	m := &Module{Object: Object{typ: ModuleType, dict: d}}
+	m.self = m
+	return m
 }
 
 func toModuleUnsafe(o *Object) *Module {
-	return (*Module)(o.toPointer())
+	return o.self.(*Module)
 }
 
 // GetFilename returns the __file__ attribute of m, raising SystemError if it

--- a/runtime/module_test.go
+++ b/runtime/module_test.go
@@ -20,6 +20,11 @@ import (
 	"testing"
 )
 
+func setModuleSelf(m *Module) *Module {
+	m.self = m
+	return m
+}
+
 func TestImportModule(t *testing.T) {
 	f := NewRootFrame()
 	invalidModule := newObject(ObjectType)
@@ -219,7 +224,7 @@ func TestModuleGetNameAndFilename(t *testing.T) {
 	cases := []invokeTestCase{
 		{args: wrapArgs(newModule("foo", "foo.py")), want: newTestTuple("foo", "foo.py").ToObject()},
 		{args: Args{mustNotRaise(ModuleType.Call(NewRootFrame(), wrapArgs("foo"), nil))}, wantExc: mustCreateException(SystemErrorType, "module filename missing")},
-		{args: wrapArgs(&Module{Object: Object{typ: ModuleType, dict: NewDict()}}), wantExc: mustCreateException(SystemErrorType, "nameless module")},
+		{args: wrapArgs(setModuleSelf(&Module{Object: Object{typ: ModuleType, dict: NewDict()}})), wantExc: mustCreateException(SystemErrorType, "nameless module")},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {
@@ -262,7 +267,7 @@ func TestModuleStrRepr(t *testing.T) {
 		{args: wrapArgs(newModule("foo", "<test>")), want: NewStr("<module 'foo' from '<test>'>").ToObject()},
 		{args: wrapArgs(newModule("foo.bar.baz", "<test>")), want: NewStr("<module 'foo.bar.baz' from '<test>'>").ToObject()},
 		{args: Args{mustNotRaise(ModuleType.Call(NewRootFrame(), wrapArgs("foo"), nil))}, want: NewStr("<module 'foo' (built-in)>").ToObject()},
-		{args: wrapArgs(&Module{Object: Object{typ: ModuleType, dict: newTestDict("__file__", "foo.py")}}), want: NewStr("<module '?' from 'foo.py'>").ToObject()},
+		{args: wrapArgs(setModuleSelf(&Module{Object: Object{typ: ModuleType, dict: newTestDict("__file__", "foo.py")}})), want: NewStr("<module '?' from 'foo.py'>").ToObject()},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(wrapFuncForTest(ToStr), &cas); err != "" {
@@ -380,5 +385,5 @@ func init() {
 }
 
 func newTestModule(name, filename string) *Module {
-	return &Module{Object: Object{typ: testModuleType, dict: newTestDict("__name__", name, "__file__", filename)}}
+	return setModuleSelf(&Module{Object: Object{typ: testModuleType, dict: newTestDict("__name__", name, "__file__", filename)}})
 }

--- a/runtime/native_test.go
+++ b/runtime/native_test.go
@@ -71,6 +71,7 @@ func TestNativeFuncCall(t *testing.T) {
 	}
 	for _, cas := range cases {
 		n := &native{Object{typ: nativeFuncType}, reflect.ValueOf(cas.fun)}
+		n.self = n
 		if err := runInvokeTestCase(n.ToObject(), &cas.invokeTestCase); err != "" {
 			t.Error(err)
 		}
@@ -176,6 +177,7 @@ func TestWrapNative(t *testing.T) {
 	d := NewDict()
 	i := 0
 	n := &native{Object{typ: nativeType}, reflect.ValueOf(&i)}
+	n.self = n
 	cases := []struct {
 		value   interface{}
 		want    *Object
@@ -354,6 +356,7 @@ func TestMaybeConvertValue(t *testing.T) {
 	type fooStruct struct{}
 	foo := &fooStruct{}
 	fooNative := &native{Object{typ: nativeType}, reflect.ValueOf(&foo)}
+	fooNative.self = fooNative
 	cases := []struct {
 		o             *Object
 		expectedRType reflect.Type

--- a/runtime/range.go
+++ b/runtime/range.go
@@ -37,7 +37,7 @@ type enumerate struct {
 }
 
 func toEnumerateUnsafe(o *Object) *enumerate {
-	return (*enumerate)(o.toPointer())
+	return o.self.(*enumerate)
 }
 
 func enumerateIter(f *Frame, o *Object) (*Object, *BaseException) {
@@ -88,6 +88,7 @@ func enumerateNew(f *Frame, t *Type, args Args, _ KWArgs) (*Object, *BaseExcepti
 		d = NewDict()
 	}
 	e := &enumerate{Object: Object{typ: t, dict: d}, index: index, iter: iter}
+	e.self = e
 	return &e.Object, nil
 }
 
@@ -126,7 +127,7 @@ type rangeIterator struct {
 }
 
 func toRangeIteratorUnsafe(o *Object) *rangeIterator {
-	return (*rangeIterator)(o.toPointer())
+	return o.self.(*rangeIterator)
 }
 
 func rangeIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
@@ -157,12 +158,14 @@ type xrange struct {
 }
 
 func toXRangeUnsafe(o *Object) *xrange {
-	return (*xrange)(o.toPointer())
+	return o.self.(*xrange)
 }
 
 func xrangeIter(f *Frame, o *Object) (*Object, *BaseException) {
 	r := toXRangeUnsafe(o)
-	return &(&rangeIterator{Object{typ: rangeIteratorType}, r.start, r.stop, r.step}).Object, nil
+	ri := &rangeIterator{Object{typ: rangeIteratorType}, r.start, r.stop, r.step}
+	ri.self = ri
+	return &ri.Object, nil
 }
 
 func xrangeNew(f *Frame, _ *Type, args Args, _ KWArgs) (*Object, *BaseException) {
@@ -192,6 +195,7 @@ func xrangeNew(f *Frame, _ *Type, args Args, _ KWArgs) (*Object, *BaseException)
 		return nil, f.RaiseType(OverflowErrorType, errResultTooLarge)
 	}
 	r := &xrange{Object: Object{typ: xrangeType}, start: start, stop: stop, step: step}
+	r.self = r
 	return &r.Object, nil
 }
 

--- a/runtime/seq.go
+++ b/runtime/seq.go
@@ -289,11 +289,12 @@ type seqIterator struct {
 
 func newSeqIterator(seq *Object) *Object {
 	iter := &seqIterator{Object: Object{typ: seqIteratorType}, seq: seq}
+	iter.self = iter
 	return &iter.Object
 }
 
 func toSeqIteratorUnsafe(o *Object) *seqIterator {
-	return (*seqIterator)(o.toPointer())
+	return o.self.(*seqIterator)
 }
 
 func seqIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {

--- a/runtime/set.go
+++ b/runtime/set.go
@@ -72,11 +72,13 @@ type Set setBase
 
 // NewSet returns an empty Set.
 func NewSet() *Set {
-	return &Set{Object{typ: SetType}, NewDict()}
+	s := &Set{Object{typ: SetType}, NewDict()}
+	s.self = s
+	return s
 }
 
 func toSetUnsafe(o *Object) *Set {
-	return (*Set)(o.toPointer())
+	return o.self.(*Set)
 }
 
 // Add inserts key into s. If key already exists then does nothing.
@@ -261,7 +263,7 @@ func initSetType(dict map[string]*Object) {
 type FrozenSet setBase
 
 func toFrozenSetUnsafe(o *Object) *FrozenSet {
-	return (*FrozenSet)(o.toPointer())
+	return o.self.(*FrozenSet)
 }
 
 // Contains returns true if key exists in s.

--- a/runtime/set_test.go
+++ b/runtime/set_test.go
@@ -326,5 +326,7 @@ func newTestFrozenSet(elems ...interface{}) *FrozenSet {
 			panic(raised)
 		}
 	}
-	return &FrozenSet{Object{typ: FrozenSetType}, d}
+	s := &FrozenSet{Object{typ: FrozenSetType}, d}
+	s.self = s
+	return s
 }

--- a/runtime/slice.go
+++ b/runtime/slice.go
@@ -32,7 +32,7 @@ type Slice struct {
 }
 
 func toSliceUnsafe(o *Object) *Slice {
-	return (*Slice)(o.toPointer())
+	return o.self.(*Slice)
 }
 
 // calcSlice returns the three range indices (start, stop, step) and the length

--- a/runtime/slice_test.go
+++ b/runtime/slice_test.go
@@ -59,11 +59,15 @@ func TestSliceCompare(t *testing.T) {
 }
 
 func TestSliceNew(t *testing.T) {
+	setSliceSelf := func(s *Slice) *Slice {
+		s.self = s
+		return s
+	}
 	cases := []invokeTestCase{
 		{args: nil, wantExc: mustCreateException(TypeErrorType, "'__new__' of 'object' requires 3 arguments")},
-		{args: wrapArgs(10), want: (&Slice{Object{typ: SliceType}, nil, NewInt(10).ToObject(), nil}).ToObject()},
-		{args: wrapArgs(1.2, "foo"), want: (&Slice{Object{typ: SliceType}, NewFloat(1.2).ToObject(), NewStr("foo").ToObject(), nil}).ToObject()},
-		{args: wrapArgs(None, None, true), want: (&Slice{Object{typ: SliceType}, None, None, True.ToObject()}).ToObject()},
+		{args: wrapArgs(10), want: setSliceSelf(&Slice{Object{typ: SliceType}, nil, NewInt(10).ToObject(), nil}).ToObject()},
+		{args: wrapArgs(1.2, "foo"), want: setSliceSelf(&Slice{Object{typ: SliceType}, NewFloat(1.2).ToObject(), NewStr("foo").ToObject(), nil}).ToObject()},
+		{args: wrapArgs(None, None, true), want: setSliceSelf(&Slice{Object{typ: SliceType}, None, None, True.ToObject()}).ToObject()},
 		{args: wrapArgs(1, 2, 3, 4), wantExc: mustCreateException(TypeErrorType, "'__new__' of 'object' requires 3 arguments")},
 	}
 	for _, cas := range cases {

--- a/runtime/str.go
+++ b/runtime/str.go
@@ -43,6 +43,7 @@ func InternStr(s string) *Str {
 	str, _ := internedStrs[s]
 	if str == nil {
 		str = &Str{Object: Object{typ: StrType}, value: s, hash: NewInt(hashString(s))}
+		str.self = str
 		internedStrs[s] = str
 	}
 	return str
@@ -60,11 +61,13 @@ func NewStr(value string) *Str {
 	if s := internedStrs[value]; s != nil {
 		return s
 	}
-	return &Str{Object: Object{typ: StrType}, value: value}
+	s := &Str{Object: Object{typ: StrType}, value: value}
+	s.self = s
+	return s
 }
 
 func toStrUnsafe(o *Object) *Str {
-	return (*Str)(o.toPointer())
+	return o.self.(*Str)
 }
 
 // Decode produces a unicode object from the bytes of s assuming they have the

--- a/runtime/super.go
+++ b/runtime/super.go
@@ -30,8 +30,10 @@ type super struct {
 	objType *Type
 }
 
+func (s *super) ToObject() *Object { return &s.Object }
+
 func toSuperUnsafe(o *Object) *super {
-	return (*super)(o.toPointer())
+	return o.self.(*super)
 }
 
 func superInit(f *Frame, o *Object, args Args, _ KWArgs) (*Object, *BaseException) {

--- a/runtime/traceback.go
+++ b/runtime/traceback.go
@@ -27,11 +27,13 @@ type Traceback struct {
 }
 
 func newTraceback(f *Frame, next *Traceback) *Traceback {
-	return &Traceback{Object{typ: TracebackType}, f, next, f.lineno}
+	t := &Traceback{Object{typ: TracebackType}, f, next, f.lineno}
+	t.self = t
+	return t
 }
 
 func toTracebackUnsafe(o *Object) *Traceback {
-	return (*Traceback)(o.toPointer())
+	return o.self.(*Traceback)
 }
 
 // ToObject upcasts f to an Object.

--- a/runtime/tuple.go
+++ b/runtime/tuple.go
@@ -32,11 +32,13 @@ func NewTuple(elems ...*Object) *Tuple {
 	if len(elems) == 0 {
 		return emptyTuple
 	}
-	return &Tuple{Object: Object{typ: TupleType}, elems: elems}
+	t := &Tuple{Object: Object{typ: TupleType}, elems: elems}
+	t.self = t
+	return t
 }
 
 func toTupleUnsafe(o *Object) *Tuple {
-	return (*Tuple)(o.toPointer())
+	return o.self.(*Tuple)
 }
 
 // GetItem returns the i'th element of t. Bounds are unchecked and therefore
@@ -59,6 +61,10 @@ func (t *Tuple) ToObject() *Object {
 var TupleType = newBasisType("tuple", reflect.TypeOf(Tuple{}), toTupleUnsafe, ObjectType)
 
 var emptyTuple = &Tuple{Object: Object{typ: TupleType}}
+
+func init() {
+	emptyTuple.self = emptyTuple
+}
 
 func tupleAdd(f *Frame, v, w *Object) (*Object, *BaseException) {
 	if !w.isInstance(TupleType) {

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestNewClass(t *testing.T) {
 	type strBasisStruct struct{ Str }
-	strBasisStructFunc := func(o *Object) *strBasisStruct { return (*strBasisStruct)(o.toPointer()) }
+	strBasisStructFunc := func(o *Object) *strBasisStruct { return o.self.(*strBasisStruct) }
 	fooType := newBasisType("Foo", reflect.TypeOf(strBasisStruct{}), strBasisStructFunc, StrType)
 	defer delete(basisTypes, fooType.basis)
 	fooType.dict = NewDict()
@@ -57,9 +57,12 @@ func TestNewClass(t *testing.T) {
 	}
 }
 
+type basisStruct struct{ Object }
+
+func (b *basisStruct) ToObject() *Object { return &b.Object }
+
 func TestNewBasisType(t *testing.T) {
-	type basisStruct struct{ Object }
-	basisStructFunc := func(o *Object) *basisStruct { return (*basisStruct)(o.toPointer()) }
+	basisStructFunc := func(o *Object) *basisStruct { return o.self.(*basisStruct) }
 	basis := reflect.TypeOf(basisStruct{})
 	typ := newBasisType("Foo", basis, basisStructFunc, ObjectType)
 	defer delete(basisTypes, basis)
@@ -79,7 +82,7 @@ func TestNewBasisType(t *testing.T) {
 	if name := typ.Name(); name != "Foo" {
 		t.Errorf(`Foo.Name() = %q, want "Foo"`, name)
 	}
-	foo := (*basisStruct)(newObject(typ).toPointer())
+	foo := newObject(typ).self.(*basisStruct)
 	if typ.slots.Basis == nil {
 		t.Error("type's Basis slot is nil")
 	} else if got := typ.slots.Basis.Fn(&foo.Object); got.Type() != basis || got.Addr().Interface().(*basisStruct) != foo {
@@ -136,9 +139,9 @@ func TestInvalidBasisType(t *testing.T) {
 
 func TestPrepareType(t *testing.T) {
 	type objectBasisStruct struct{ Object }
-	objectBasisStructFunc := func(o *Object) *objectBasisStruct { return (*objectBasisStruct)(o.toPointer()) }
+	objectBasisStructFunc := func(o *Object) *objectBasisStruct { return o.self.(*objectBasisStruct) }
 	type strBasisStruct struct{ Str }
-	strBasisStructFunc := func(o *Object) *strBasisStruct { return (*strBasisStruct)(o.toPointer()) }
+	strBasisStructFunc := func(o *Object) *strBasisStruct { return o.self.(*strBasisStruct) }
 	cases := []struct {
 		basis     reflect.Type
 		basisFunc interface{}
@@ -334,6 +337,7 @@ func TestTypeGetAttribute(t *testing.T) {
 	//   __metaclass__ = BarMeta
 	// bar = Bar()
 	barType := &Type{Object: Object{typ: barMetaType}, name: "Bar", basis: fooType.basis, bases: []*Type{fooType}}
+	barType.self = barType
 	barType.dict = newTestDict("bar", "Bar's bar", "foo", 101, "barsetter", setter, "barmetasetter", "NOT setter")
 	bar := newObject(barType)
 	prepareType(barType)

--- a/runtime/unicode.go
+++ b/runtime/unicode.go
@@ -42,11 +42,13 @@ func NewUnicode(value string) *Unicode {
 
 // NewUnicodeFromRunes returns a new Unicode holding the given runes.
 func NewUnicodeFromRunes(value []rune) *Unicode {
-	return &Unicode{Object{typ: UnicodeType}, value}
+	u := &Unicode{Object{typ: UnicodeType}, value}
+	u.self = u
+	return u
 }
 
 func toUnicodeUnsafe(o *Object) *Unicode {
-	return (*Unicode)(o.toPointer())
+	return o.self.(*Unicode)
 }
 
 // Encode translates the runes in s into a str with the given encoding.

--- a/runtime/unicode_test.go
+++ b/runtime/unicode_test.go
@@ -21,6 +21,11 @@ import (
 	"unicode"
 )
 
+func setUnicodeSelf(u *Unicode) *Unicode {
+	u.self = u
+	return u
+}
+
 func TestUnicodeNewUnicode(t *testing.T) {
 	cases := []struct {
 		s    string
@@ -256,7 +261,7 @@ func TestUnicodeNew(t *testing.T) {
 		{args: wrapArgs(UnicodeType, "foo\xffbar", "utf8", "replace"), want: NewUnicode("foo\ufffdbar").ToObject()},
 		{args: wrapArgs(UnicodeType, "\xff", "utf-8", "noexist"), wantExc: mustCreateException(LookupErrorType, "unknown error handler name 'noexist'")},
 		{args: wrapArgs(UnicodeType, "\xff", "utf16"), wantExc: mustCreateException(LookupErrorType, "unknown encoding: utf16")},
-		{args: wrapArgs(strictEqType, NewUnicode("foo")), want: (&Unicode{Object{typ: strictEqType}, bytes.Runes([]byte("foo"))}).ToObject()},
+		{args: wrapArgs(strictEqType, NewUnicode("foo")), want: setUnicodeSelf(&Unicode{Object{typ: strictEqType}, bytes.Runes([]byte("foo"))}).ToObject()},
 	}
 	for _, cas := range cases {
 		if err := runInvokeMethodTestCase(UnicodeType, "__new__", &cas); err != "" {
@@ -274,7 +279,7 @@ func TestUnicodeNewNotSubtype(t *testing.T) {
 
 func TestUnicodeNewSubclass(t *testing.T) {
 	fooType := newTestClass("Foo", []*Type{UnicodeType}, NewDict())
-	bar := (&Unicode{Object{typ: fooType}, bytes.Runes([]byte("bar"))}).ToObject()
+	bar := setUnicodeSelf(&Unicode{Object{typ: fooType}, bytes.Runes([]byte("bar"))}).ToObject()
 	fun := wrapFuncForTest(func(f *Frame) *BaseException {
 		got, raised := UnicodeType.Call(f, []*Object{bar}, nil)
 		if raised != nil {


### PR DESCRIPTION
Rather than forcing casts from an *Object to the desired type, we store a "self" reference on the object to allow us to get back to the containing type. This does increase the amount of ram each object takes up (~2 more pointers), the chance of miscasting code goes down dramatically.

There is still a bad cast resulting from values coming out of WrapNative, and this has helped corner that cast. The actual fix is quite involved, but this should prevent similar problems in the future (hopefully).

I expect that this might be a little controversial, but the WrapNative bug I am trying to pin down is the result of the following:
```
type foo uint64
WrapNative(foo(MaxInt+100))
```
The returned value is a memory mashup of an Int and a Long. There is a similar test already, but it only uses a raw `uint64` rather than something like `foo` above.

Thoughts?