### PR TITLE
Fix link to jyni.org in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ supported).
 2. C extension modules: Grumpy has a different API and object layout than
    CPython and so supporting C extensions would be difficult. In principle it's
    possible to support them via an API bridge layer like the one that
-   [JyNI](jyni.org) provides for Jython but it would be hard to maintain and
+   [JyNI](http://jyni.org) provides for Jython but it would be hard to maintain and
    would add significant overhead when calling into and out of extension
    modules.
 


### PR DESCRIPTION
The link was interpreted as local and did link to https://github.com/google/grumpy/blob/master/jyni.org instead of http://jyni.org