### PR TITLE
export list.sort

### DIFF
--- a/runtime/list.go
+++ b/runtime/list.go
@@ -336,10 +336,20 @@ func listSetItem(f *Frame, o, key, value *Object) *BaseException {
 	return f.RaiseType(TypeErrorType, fmt.Sprintf("list indices must be integers, not %s", key.Type().Name()))
 }
 
+func listSort(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+	if raised := checkMethodArgs(f, "sort", args, ListType); raised != nil {
+		return nil, raised
+	}
+	l := toListUnsafe(args[0])
+	l.Sort(f)
+	return None, nil
+}
+
 func initListType(dict map[string]*Object) {
 	dict["append"] = newBuiltinFunction("append", listAppend).ToObject()
 	dict["insert"] = newBuiltinFunction("insert", listInsert).ToObject()
 	dict["reverse"] = newBuiltinFunction("reverse", listReverse).ToObject()
+	dict["sort"] = newBuiltinFunction("sort", listSort).ToObject()
 	ListType.slots.Add = &binaryOpSlot{listAdd}
 	ListType.slots.Contains = &binaryOpSlot{listContains}
 	ListType.slots.Eq = &binaryOpSlot{listEq}

--- a/runtime/list.go
+++ b/runtime/list.go
@@ -337,6 +337,7 @@ func listSetItem(f *Frame, o, key, value *Object) *BaseException {
 }
 
 func listSort(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+	// TODO: Support (cmp=None, key=None, reverse=False)
 	if raised := checkMethodArgs(f, "sort", args, ListType); raised != nil {
 		return nil, raised
 	}

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -393,14 +393,10 @@ func TestListSetItem(t *testing.T) {
 
 func TestListSort(t *testing.T) {
 	fun := newBuiltinFunction("TestListSort", func(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
-		if raised := checkFunctionArgs(f, "TestListSort", args, ListType); raised != nil {
+		if _, raised := listSort(f, args, KWArgs{}); raised != nil {
 			return nil, raised
 		}
-		l := toListUnsafe(args[0])
-		if raised := l.Sort(f); raised != nil {
-			return nil, raised
-		}
-		return l.ToObject(), nil
+		return args[0], nil
 	}).ToObject()
 	cases := []invokeTestCase{
 		{args: wrapArgs(NewList()), want: NewList().ToObject()},
@@ -408,6 +404,8 @@ func TestListSort(t *testing.T) {
 		{args: wrapArgs(newTestList(true, false)), want: newTestList(false, true).ToObject()},
 		{args: wrapArgs(newTestList(1, 2, 0, 3)), want: newTestRange(4).ToObject()},
 		{args: wrapArgs(newTestRange(100)), want: newTestRange(100).ToObject()},
+		{args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'sort' requires a 'list' object but received a 'int'")},
+		{args: wrapArgs(NewList(), 1), wantExc: mustCreateException(TypeErrorType, "'sort' of 'list' requires 1 arguments")},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -408,6 +408,8 @@ func TestListSort(t *testing.T) {
 		{args: wrapArgs(newTestList(true, false)), want: newTestList(false, true).ToObject()},
 		{args: wrapArgs(newTestList(1, 2, 0, 3)), want: newTestRange(4).ToObject()},
 		{args: wrapArgs(newTestRange(100)), want: newTestRange(100).ToObject()},
+		{args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'TestListSort' requires a 'list' object but received a \"int\"")},
+		{args: wrapArgs(newTestList("foo", "bar"), 2), wantExc: mustCreateException(TypeErrorType, "'TestListSort' requires 1 arguments")},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -392,8 +392,9 @@ func TestListSetItem(t *testing.T) {
 }
 
 func TestListSort(t *testing.T) {
+	sort := mustNotRaise(GetAttr(NewRootFrame(), ListType.ToObject(), NewStr("sort"), nil))
 	fun := newBuiltinFunction("TestListSort", func(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
-		if _, raised := listSort(f, args, KWArgs{}); raised != nil {
+		if _, raised := sort.Call(f, args, nil); raised != nil {
 			return nil, raised
 		}
 		return args[0], nil
@@ -404,7 +405,7 @@ func TestListSort(t *testing.T) {
 		{args: wrapArgs(newTestList(true, false)), want: newTestList(false, true).ToObject()},
 		{args: wrapArgs(newTestList(1, 2, 0, 3)), want: newTestRange(4).ToObject()},
 		{args: wrapArgs(newTestRange(100)), want: newTestRange(100).ToObject()},
-		{args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'sort' requires a 'list' object but received a 'int'")},
+		{args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "unbound method sort() must be called with list instance as first argument (got int instance instead)")},
 		{args: wrapArgs(NewList(), 1), wantExc: mustCreateException(TypeErrorType, "'sort' of 'list' requires 1 arguments")},
 	}
 	for _, cas := range cases {

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -408,8 +408,6 @@ func TestListSort(t *testing.T) {
 		{args: wrapArgs(newTestList(true, false)), want: newTestList(false, true).ToObject()},
 		{args: wrapArgs(newTestList(1, 2, 0, 3)), want: newTestRange(4).ToObject()},
 		{args: wrapArgs(newTestRange(100)), want: newTestRange(100).ToObject()},
-		{args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'TestListSort' requires a 'list' object but received a \"int\"")},
-		{args: wrapArgs(newTestList("foo", "bar"), 2), wantExc: mustCreateException(TypeErrorType, "'TestListSort' requires 1 arguments")},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -392,8 +392,8 @@ func TestListSetItem(t *testing.T) {
 }
 
 func TestListSort(t *testing.T) {
-	fun := newBuiltinFunction("TestListSetItem", func(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
-		if raised := checkFunctionArgs(f, "TestListSetItem", args, ListType); raised != nil {
+	fun := newBuiltinFunction("TestListSort", func(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+		if raised := checkFunctionArgs(f, "TestListSort", args, ListType); raised != nil {
 			return nil, raised
 		}
 		l := toListUnsafe(args[0])

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -1,0 +1,42 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+l0_3 = [0, 1, 2, 3]
+l0_3_bis = list(l0_3)
+assert l0_3 == l0_3_bis
+assert l0_3 is not l0_3_bis
+assert list(()) == []
+assert list((0, 1, 2, 3)) == [0, 1, 2, 3]
+assert list('') == []
+assert list('spam') == ['s', 'p', 'a', 'm']
+
+assert [] is not True
+assert [42]
+
+assert [] is not []
+
+assert len([]) == 0
+assert len([0]) == 1
+assert len([0, 1, 2]) == 3
+
+a = [3, 2, 4, 1]
+b = []
+c = ["a", "e", "c", "b"]
+
+a.sort()
+assert a == [1, 2, 3, 4]
+b.sort()
+assert b == []
+c.sort()
+assert c == ["a", "b", "c", "e"]

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-l0_3 = [0, 1, 2, 3]
-l0_3_bis = list(l0_3)
-assert l0_3 == l0_3_bis
-assert l0_3 is not l0_3_bis
+a = [0, 1, 2, 3]
+b = list(a)
+assert a == b
+assert a is not b
 assert list(()) == []
 assert list((0, 1, 2, 3)) == [0, 1, 2, 3]
 assert list('') == []


### PR DESCRIPTION
I think basic list.sort can be exported, most tests cases are already there.

Note that, cmd, key, and reversed options are not yet implemented.