### PR TITLE
Make `list.sort` stable

### DIFF
--- a/runtime/list.go
+++ b/runtime/list.go
@@ -114,7 +114,9 @@ func (l *List) Sort(f *Frame) (raised *BaseException) {
 		}
 		raised = sorter.raised
 	}()
-	sort.Sort(sorter)
+	// Python guarantees stability.  See note (9) in:
+	// https://docs.python.org/2/library/stdtypes.html#mutable-sequence-types
+	sort.Stable(sorter)
 	return nil
 }
 


### PR DESCRIPTION
Python gaurantees that its builtin sort for mutable sequences is stable.
For more details, see note (9) in:

  * https://docs.python.org/2/library/stdtypes.html#mutable-sequence-types

I couldn't come up with a decent way to test this.