### PR TITLE
Try `__cmp__` when rich comparisons aren't handy

### DIFF
--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -152,6 +152,85 @@ func TestBinaryOps(t *testing.T) {
 	}
 }
 
+func TestCompare(t *testing.T) {
+	badCmpType := newTestClass("BadCmp", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return nil, f.RaiseType(TypeErrorType, "uh oh")
+		}).ToObject(),
+	}))
+	cmpLtType := newTestClass("Lt", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NewInt(-1).ToObject(), nil
+		}).ToObject(),
+	}))
+	cmpEqType := newTestClass("Eq", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NewInt(0).ToObject(), nil
+		}).ToObject(),
+	}))
+	cmpGtType := newTestClass("Gt", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NewInt(1).ToObject(), nil
+		}).ToObject(),
+	}))
+	cmpByEqType := newTestClass("EqCmp", []*Type{IntType}, newStringDict(map[string]*Object{
+		"__eq__": newBuiltinFunction("__eq__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return True.ToObject(), nil
+		}).ToObject(),
+	}))
+	badCmpByEqType := newTestClass("BadEqCmp", []*Type{IntType}, newStringDict(map[string]*Object{
+		"__eq__": newBuiltinFunction("__eq__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return nil, f.RaiseType(TypeErrorType, "uh oh")
+		}).ToObject(),
+	}))
+	badNonZeroType := newTestClass("BadNonZeroType", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__nonzero__": newBuiltinFunction("__nonzero__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return nil, f.RaiseType(TypeErrorType, "uh oh")
+		}).ToObject(),
+	}))
+	worseCmpByEqType := newTestClass("WorseEqCmp", []*Type{IntType}, newStringDict(map[string]*Object{
+		"__eq__": newBuiltinFunction("__eq__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return newObject(badNonZeroType), nil
+		}).ToObject(),
+	}))
+	cmpNonIntResultType := newTestClass("CmpNonIntResult", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NewStr("foo").ToObject(), nil
+		}).ToObject(),
+	}))
+	cases := []invokeTestCase{
+		// Test `__cmp__` less than.
+		{args: wrapArgs(newObject(cmpLtType), None), want: NewInt(-1).ToObject()},
+		{args: wrapArgs(None, newObject(cmpGtType)), want: NewInt(-1).ToObject()},
+		// Test `__cmp__` equals.
+		{args: wrapArgs(newObject(cmpEqType), None), want: NewInt(0).ToObject()},
+		{args: wrapArgs(None, newObject(cmpEqType)), want: NewInt(0).ToObject()},
+		// Test `__cmp__` greater than.
+		{args: wrapArgs(newObject(cmpGtType), None), want: NewInt(1).ToObject()},
+		{args: wrapArgs(None, newObject(cmpLtType)), want: NewInt(1).ToObject()},
+		// Test `__cmp__` fallback to rich comparison.
+		{args: wrapArgs(newObject(cmpByEqType), None), want: NewInt(0).ToObject()},
+		{args: wrapArgs(None, newObject(cmpByEqType)), want: NewInt(0).ToObject()},
+		// Test bad `__cmp__` fallback to rich comparison.
+		{args: wrapArgs(newObject(badCmpByEqType), None), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		{args: wrapArgs(None, newObject(badCmpByEqType)), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		// Test bad `__cmp__` fallback to rich comparison where a bad object is returned from `__eq__`.
+		{args: wrapArgs(newObject(worseCmpByEqType), None), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		{args: wrapArgs(None, newObject(worseCmpByEqType)), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		// Test bad `__cmp__`.
+		{args: wrapArgs(newObject(badCmpType), None), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		{args: wrapArgs(None, newObject(badCmpType)), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		// Test bad `__cmp__` with non-int result.
+		{args: wrapArgs(newObject(cmpNonIntResultType), None), wantExc: mustCreateException(TypeErrorType, "an integer is required")},
+		{args: wrapArgs(None, newObject(cmpNonIntResultType)), wantExc: mustCreateException(TypeErrorType, "an integer is required")},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(wrapFuncForTest(Compare), &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
 func TestCompareDefault(t *testing.T) {
 	o1, o2 := newObject(ObjectType), newObject(ObjectType)
 	// Make sure uintptr(o1) < uintptr(o2).
@@ -775,6 +854,47 @@ func TestResolveGlobal(t *testing.T) {
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
+func TestRichCompare(t *testing.T) {
+	badCmpType := newTestClass("BadCmp", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return nil, f.RaiseType(TypeErrorType, "uh oh")
+		}).ToObject(),
+	}))
+	cmpEqType := newTestClass("BadCmp", []*Type{ObjectType}, newStringDict(map[string]*Object{
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NewInt(0).ToObject(), nil
+		}).ToObject(),
+	}))
+	cmpByEqType := newTestClass("Eq", []*Type{IntType}, newStringDict(map[string]*Object{
+		"__eq__": newBuiltinFunction("__eq__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return True.ToObject(), nil
+		}).ToObject(),
+		"__cmp__": newBuiltinFunction("__cmp__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return NotImplemented, nil
+		}).ToObject(),
+	}))
+	badCmpEqType := newTestClass("Eq", []*Type{IntType}, newStringDict(map[string]*Object{
+		"__eq__": newBuiltinFunction("__eq__", func(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+			return nil, f.RaiseType(TypeErrorType, "uh oh")
+		}).ToObject(),
+	}))
+	cases := []invokeTestCase{
+		// Test `__eq__` fallback to `__cmp__`.
+		{args: wrapArgs(newObject(cmpEqType), newObject(cmpEqType)), want: compareAllResultEq},
+		// Test `__cmp__` fallback to `__eq__`.
+		{args: wrapArgs(newObject(cmpByEqType), newObject(cmpByEqType)), want: compareAllResultEq},
+		// Test rich compare fallback to bad `__cmp__`.
+		{args: wrapArgs(newObject(badCmpType), newObject(badCmpType)), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+		// Test bad `__eq__` where the second object being compared is a subclass of the first.
+		{args: wrapArgs(NewInt(13).ToObject(), newObject(badCmpEqType)), wantExc: mustCreateException(TypeErrorType, "uh oh")},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(compareAll, &cas); err != "" {
 			t.Error(err)
 		}
 	}

--- a/testing/compare_test.py
+++ b/testing/compare_test.py
@@ -21,3 +21,87 @@ assert [] != None  # pylint: disable=g-equals-none,g-explicit-bool-comparison
 assert int >= "az"
 assert "foo" >= "foo"
 assert True > False
+
+# Test rich comparisons.
+
+class RichCmp(object):
+  def __init__(self, x):
+    self.x = x
+    self.lt_called = False
+    self.le_called = False
+    self.eq_called = False
+    self.ge_called = False
+    self.gt_called = False
+
+  def __lt__(self, other):
+    self.lt_called = True
+    return self.x < other.x
+
+  def __le__(self, other):
+    self.le_called = True
+    return self.x <= other.x
+
+  def __eq__(self, other):
+    self.eq_called = True
+    return self.x == other.x
+
+  def __ge__(self, other):
+    self.ge_called = True
+    return self.x >= other.x
+
+  def __gt__(self, other):
+    self.gt_called = True
+    return self.x > other.x
+
+class Cmp(object):
+  def __init__(self, x):
+    self.cmp_called = False
+    self.x = x
+
+  def __cmp__(self, other):
+    self.cmp_called = True
+    return cmp(self.x, other.x)
+
+# Test that rich comparison methods are called.
+
+a, b = RichCmp(1), RichCmp(2)
+assert a < b
+assert a.lt_called
+
+a, b = RichCmp(1), RichCmp(2)
+assert a <= b
+assert a.le_called
+
+a, b = RichCmp(3), RichCmp(3)
+assert a == b
+assert a.eq_called
+
+a, b = RichCmp(5), RichCmp(4)
+assert a >= b
+assert a.ge_called
+
+a, b = RichCmp(5), RichCmp(4)
+assert a > b
+assert a.gt_called
+
+# Test rich comparison falling back to a 3-way comparison
+
+a, b = Cmp(1), Cmp(2)
+assert a < b
+assert a.cmp_called
+
+a, b = Cmp(1), Cmp(2)
+assert a <= b
+assert a.cmp_called
+
+a, b = Cmp(3), Cmp(3)
+assert a == b
+assert a.cmp_called
+
+a, b = Cmp(5), Cmp(4)
+assert a > b
+assert a.cmp_called
+
+a, b = Cmp(5), Cmp(4)
+assert a >= b
+assert a.cmp_called


### PR DESCRIPTION
When comparing two objects and the appropriate rich comparison
method doesn't exist, the `__cmp__` method should be tried. For
example, if `a == b` is executed and neither `a` or `b` have
the appropriate rich comparison methods, then the equivalent
of `a.__cmp__(b) == 0` should be tried.