### PR TITLE
Add _collections to third_party/pypy (deque)

### DIFF
--- a/lib/_collections.py
+++ b/lib/_collections.py
@@ -1,4 +1,0 @@
-class deque(object):
-
-  def __init__(self, *_):
-    raise NotImplementedError

--- a/third_party/pypy/_collections.py
+++ b/third_party/pypy/_collections.py
@@ -11,15 +11,16 @@
 # try:
 #     from threading import _get_ident as _thread_ident
 # except ImportError:
+#     def _thread_ident():
+#         return -1
 
 import thread
 _thread_ident = thread.get_ident
 
-
 n = 30
 LFTLNK = n
-RGTLNK = n + 1
-BLOCKSIZ = n + 2
+RGTLNK = n+1
+BLOCKSIZ = n+2
 
 # The deque's size limit is d.maxlen.  The limit can be zero or positive, or
 # None.  After an item is added to a deque, we check to see if the size has
@@ -27,414 +28,410 @@ BLOCKSIZ = n + 2
 # popping an item off of the opposite end.  The methods that can trigger this
 # are append(), appendleft(), extend(), and extendleft().
 
-
 class deque(object):
 
-  def __new__(cls, iterable=(), *args, **kw):
-    self = super(deque, cls).__new__(cls)
-    self.clear()
-    return self
+    def __new__(cls, iterable=(), *args, **kw):
+        self = super(deque, cls).__new__(cls)
+        self.clear()
+        return self
 
-  def __init__(self, iterable=(), maxlen=None):
-    self.clear()
-    if maxlen is not None:
-      if maxlen < 0:
-        raise ValueError("maxlen must be non-negative")
-    self._maxlen = maxlen
-    add = self.append
-    for elem in iterable:
-      add(elem)
+    def __init__(self, iterable=(), maxlen=None):
+        self.clear()
+        if maxlen is not None:
+            if maxlen < 0:
+                raise ValueError("maxlen must be non-negative")
+        self._maxlen = maxlen
+        add = self.append
+        for elem in iterable:
+            add(elem)
 
-  @property
-  def maxlen(self):
-    return self._maxlen
-  # TODO: Make this a decorator once they're implemented.
-  maxlen = property(maxlen)
+    # @property
+    def maxlen(self):
+        return self._maxlen
+    # TODO: Make this a decorator once they're implemented.
+    maxlen = property(maxlen)
+    def clear(self):
+        self.right = self.left = [None] * BLOCKSIZ
+        self.rightndx = n//2   # points to last written element
+        self.leftndx = n//2+1
+        self.length = 0
+        self.state = 0
 
-  def clear(self):
-    self.right = self.left = [None] * BLOCKSIZ
-    self.rightndx = n // 2   # points to last written element
-    self.leftndx = n // 2 + 1
-    self.length = 0
-    self.state = 0
+    def append(self, x):
+        self.state += 1
+        self.rightndx += 1
+        if self.rightndx == n:
+            newblock = [None] * BLOCKSIZ
+            self.right[RGTLNK] = newblock
+            newblock[LFTLNK] = self.right
+            self.right = newblock
+            self.rightndx = 0
+        self.length += 1
+        self.right[self.rightndx] = x
+        if self.maxlen is not None and self.length > self.maxlen:
+            self.popleft()
 
-  def append(self, x):
-    self.state += 1
-    self.rightndx += 1
-    if self.rightndx == n:
-      newblock = [None] * BLOCKSIZ
-      self.right[RGTLNK] = newblock
-      newblock[LFTLNK] = self.right
-      self.right = newblock
-      self.rightndx = 0
-    self.length += 1
-    self.right[self.rightndx] = x
-    if self.maxlen is not None and self.length > self.maxlen:
-      self.popleft()
+    def appendleft(self, x):
+        self.state += 1
+        self.leftndx -= 1
+        if self.leftndx == -1:
+            newblock = [None] * BLOCKSIZ
+            self.left[LFTLNK] = newblock
+            newblock[RGTLNK] = self.left
+            self.left = newblock
+            self.leftndx = n-1
+        self.length += 1
+        self.left[self.leftndx] = x
+        if self.maxlen is not None and self.length > self.maxlen:
+            self.pop()
 
-  def appendleft(self, x):
-    self.state += 1
-    self.leftndx -= 1
-    if self.leftndx == -1:
-      newblock = [None] * BLOCKSIZ
-      self.left[LFTLNK] = newblock
-      newblock[RGTLNK] = self.left
-      self.left = newblock
-      self.leftndx = n - 1
-    self.length += 1
-    self.left[self.leftndx] = x
-    if self.maxlen is not None and self.length > self.maxlen:
-      self.pop()
+    def extend(self, iterable):
+        if iterable is self:
+            iterable = list(iterable)
+        for elem in iterable:
+            self.append(elem)
 
-  def extend(self, iterable):
-    if iterable is self:
-      iterable = list(iterable)
-    for elem in iterable:
-      self.append(elem)
+    def extendleft(self, iterable):
+        if iterable is self:
+            iterable = list(iterable)
+        for elem in iterable:
+            self.appendleft(elem)
 
-  def extendleft(self, iterable):
-    if iterable is self:
-      iterable = list(iterable)
-    for elem in iterable:
-      self.appendleft(elem)
+    def pop(self):
+        if self.left is self.right and self.leftndx > self.rightndx:
+            raise IndexError("pop from an empty deque")
+        x = self.right[self.rightndx]
+        self.right[self.rightndx] = None
+        self.length -= 1
+        self.rightndx -= 1
+        self.state += 1
+        if self.rightndx == -1:
+            prevblock = self.right[LFTLNK]
+            if prevblock is None:
+                # the deque has become empty; recenter instead of freeing block
+                self.rightndx = n//2
+                self.leftndx = n//2+1
+            else:
+                prevblock[RGTLNK] = None
+                self.right[LFTLNK] = None
+                self.right = prevblock
+                self.rightndx = n-1
+        return x
 
-  def pop(self):
-    if self.left is self.right and self.leftndx > self.rightndx:
-      raise IndexError("pop from an empty deque")
-    x = self.right[self.rightndx]
-    self.right[self.rightndx] = None
-    self.length -= 1
-    self.rightndx -= 1
-    self.state += 1
-    if self.rightndx == -1:
-      prevblock = self.right[LFTLNK]
-      if prevblock is None:
-        # the deque has become empty; recenter instead of freeing block
-        self.rightndx = n // 2
-        self.leftndx = n // 2 + 1
-      else:
-        prevblock[RGTLNK] = None
-        self.right[LFTLNK] = None
-        self.right = prevblock
-        self.rightndx = n - 1
-    return x
+    def popleft(self):
+        if self.left is self.right and self.leftndx > self.rightndx:
+            raise IndexError("pop from an empty deque")
+        x = self.left[self.leftndx]
+        self.left[self.leftndx] = None
+        self.length -= 1
+        self.leftndx += 1
+        self.state += 1
+        if self.leftndx == n:
+            prevblock = self.left[RGTLNK]
+            if prevblock is None:
+                # the deque has become empty; recenter instead of freeing block
+                self.rightndx = n//2
+                self.leftndx = n//2+1
+            else:
+                prevblock[LFTLNK] = None
+                self.left[RGTLNK] = None
+                self.left = prevblock
+                self.leftndx = 0
+        return x
 
-  def popleft(self):
-    if self.left is self.right and self.leftndx > self.rightndx:
-      raise IndexError("pop from an empty deque")
-    x = self.left[self.leftndx]
-    self.left[self.leftndx] = None
-    self.length -= 1
-    self.leftndx += 1
-    self.state += 1
-    if self.leftndx == n:
-      prevblock = self.left[RGTLNK]
-      if prevblock is None:
-        # the deque has become empty; recenter instead of freeing block
-        self.rightndx = n // 2
-        self.leftndx = n // 2 + 1
-      else:
-        prevblock[LFTLNK] = None
-        self.left[RGTLNK] = None
-        self.left = prevblock
-        self.leftndx = 0
-    return x
+    def count(self, value):
+        c = 0
+        for item in self:
+            if item == value:
+                c += 1
+        return c
 
-  def count(self, value):
-    c = 0
-    for item in self:
-      if item == value:
-        c += 1
-    return c
+    def remove(self, value):
+        # Need to defend mutating or failing comparisons
+        i = 0
+        try:
+            for i in range(len(self)):
+                if self[0] == value:
+                    self.popleft()
+                    return
+                self.append(self.popleft())
+            i += 1
+            raise ValueError("deque.remove(x): x not in deque")
+        finally:
+            self.rotate(i)
 
-  def remove(self, value):
-    # Need to defend mutating or failing comparisons
-    i = 0
-    try:
-      for i in range(len(self)):
-        if self[0] == value:
-          self.popleft()
-          return
-        self.append(self.popleft())
-      i += 1
-      raise ValueError("deque.remove(x): x not in deque")
-    finally:
-      self.rotate(i)
+    def rotate(self, n=1):
+        length = len(self)
+        if length <= 1:
+            return
+        halflen = length >> 1
+        if n > halflen or n < -halflen:
+            n %= length
+            if n > halflen:
+                n -= length
+            elif n < -halflen:
+                n += length
+        while n > 0:
+            self.appendleft(self.pop())
+            n -= 1
+        while n < 0:
+            self.append(self.popleft())
+            n += 1
 
-  def rotate(self, n=1):
-    length = len(self)
-    if length <= 1:
-      return
-    halflen = length >> 1
-    if n > halflen or n < -halflen:
-      n %= length
-      if n > halflen:
-        n -= length
-      elif n < -halflen:
-        n += length
-    while n > 0:
-      self.appendleft(self.pop())
-      n -= 1
-    while n < 0:
-      self.append(self.popleft())
-      n += 1
+    def reverse(self):
+        "reverse *IN PLACE*"
+        leftblock = self.left
+        rightblock = self.right
+        leftindex = self.leftndx
+        rightindex = self.rightndx
+        for i in range(self.length // 2):
+            # Validate that pointers haven't met in the middle
+            assert leftblock != rightblock or leftindex < rightindex
 
-  def reverse(self):
-    "reverse *IN PLACE*"
-    leftblock = self.left
-    rightblock = self.right
-    leftindex = self.leftndx
-    rightindex = self.rightndx
-    for i in range(self.length // 2):
-      # Validate that pointers haven't met in the middle
-      assert leftblock != rightblock or leftindex < rightindex
+            # Swap
+            (rightblock[rightindex], leftblock[leftindex]) = (
+                leftblock[leftindex], rightblock[rightindex])
 
-      # Swap
-      (rightblock[rightindex], leftblock[leftindex]) = (
-          leftblock[leftindex], rightblock[rightindex])
+            # Advance left block/index pair
+            leftindex += 1
+            if leftindex == n:
+                leftblock = leftblock[RGTLNK]
+                assert leftblock is not None
+                leftindex = 0
 
-      # Advance left block/index pair
-      leftindex += 1
-      if leftindex == n:
-        leftblock = leftblock[RGTLNK]
-        assert leftblock is not None
-        leftindex = 0
+            # Step backwards with the right block/index pair
+            rightindex -= 1
+            if rightindex == -1:
+                rightblock = rightblock[LFTLNK]
+                assert rightblock is not None
+                rightindex = n - 1
 
-      # Step backwards with the right block/index pair
-      rightindex -= 1
-      if rightindex == -1:
-        rightblock = rightblock[LFTLNK]
-        assert rightblock is not None
-        rightindex = n - 1
-
-  def __repr__(self):
-    threadlocalattr = '__repr' + str(_thread_ident())
-    if threadlocalattr in self.__dict__:
-      return 'deque([...])'
-    else:
-      self.__dict__[threadlocalattr] = True
-      try:
-        if self.maxlen is not None:
-          return 'deque(%r, maxlen=%s)' % (list(self), self.maxlen)
+    def __repr__(self):
+        threadlocalattr = '__repr' + str(_thread_ident())
+        if threadlocalattr in self.__dict__:
+            return 'deque([...])'
         else:
-          return 'deque(%r)' % (list(self),)
-      finally:
-        del self.__dict__[threadlocalattr]
+            self.__dict__[threadlocalattr] = True
+            try:
+                if self.maxlen is not None:
+                    return 'deque(%r, maxlen=%s)' % (list(self), self.maxlen)
+                else:
+                    return 'deque(%r)' % (list(self),)
+            finally:
+                del self.__dict__[threadlocalattr]
 
-  def __iter__(self):
-    return deque_iterator(self, self._iter_impl)
+    def __iter__(self):
+        return deque_iterator(self, self._iter_impl)
 
-  def _iter_impl(self, original_state, giveup):
-    if self.state != original_state:
-      giveup()
-    block = self.left
-    while block:
-      l, r = 0, n
-      if block is self.left:
-        l = self.leftndx
-      if block is self.right:
-        r = self.rightndx + 1
-      for elem in block[l:r]:
-        yield elem
+    def _iter_impl(self, original_state, giveup):
         if self.state != original_state:
-          giveup()
-      block = block[RGTLNK]
+            giveup()
+        block = self.left
+        while block:
+            l, r = 0, n
+            if block is self.left:
+                l = self.leftndx
+            if block is self.right:
+                r = self.rightndx + 1
+            for elem in block[l:r]:
+                yield elem
+                if self.state != original_state:
+                    giveup()
+            block = block[RGTLNK]
 
-  def __reversed__(self):
-    return deque_iterator(self, self._reversed_impl)
+    def __reversed__(self):
+        return deque_iterator(self, self._reversed_impl)
 
-  def _reversed_impl(self, original_state, giveup):
-    if self.state != original_state:
-      giveup()
-    block = self.right
-    while block:
-      l, r = 0, n
-      if block is self.left:
-        l = self.leftndx
-      if block is self.right:
-        r = self.rightndx + 1
-      for elem in reversed(block[l:r]):
-        yield elem
+    def _reversed_impl(self, original_state, giveup):
         if self.state != original_state:
-          giveup()
-      block = block[LFTLNK]
+            giveup()
+        block = self.right
+        while block:
+            l, r = 0, n
+            if block is self.left:
+                l = self.leftndx
+            if block is self.right:
+                r = self.rightndx + 1
+            for elem in reversed(block[l:r]):
+                yield elem
+                if self.state != original_state:
+                    giveup()
+            block = block[LFTLNK]
 
-  def __len__(self):
-    #sum = 0
-    #block = self.left
-    # while block:
-    #    sum += n
-    #    block = block[RGTLNK]
-    # return sum + self.rightndx - self.leftndx + 1 - n
-    return self.length
+    def __len__(self):
+        #sum = 0
+        #block = self.left
+        #while block:
+        #    sum += n
+        #    block = block[RGTLNK]
+        #return sum + self.rightndx - self.leftndx + 1 - n
+        return self.length
 
-  def __getref(self, index):
-    if index >= 0:
-      block = self.left
-      while block:
-        l, r = 0, n
-        if block is self.left:
-          l = self.leftndx
-        if block is self.right:
-          r = self.rightndx + 1
-        span = r - l
-        if index < span:
-          return block, l + index
-        index -= span
-        block = block[RGTLNK]
-    else:
-      block = self.right
-      while block:
-        l, r = 0, n
-        if block is self.left:
-          l = self.leftndx
-        if block is self.right:
-          r = self.rightndx + 1
-        negative_span = l - r
-        if index >= negative_span:
-          return block, r + index
-        index -= negative_span
-        block = block[LFTLNK]
-    raise IndexError("deque index out of range")
-
-  def __getitem__(self, index):
-    block, index = self.__getref(index)
-    return block[index]
-
-  def __setitem__(self, index, value):
-    block, index = self.__getref(index)
-    block[index] = value
-
-  def __delitem__(self, index):
-    length = len(self)
-    if index >= 0:
-      if index >= length:
+    def __getref(self, index):
+        if index >= 0:
+            block = self.left
+            while block:
+                l, r = 0, n
+                if block is self.left:
+                    l = self.leftndx
+                if block is self.right:
+                    r = self.rightndx + 1
+                span = r-l
+                if index < span:
+                    return block, l+index
+                index -= span
+                block = block[RGTLNK]
+        else:
+            block = self.right
+            while block:
+                l, r = 0, n
+                if block is self.left:
+                    l = self.leftndx
+                if block is self.right:
+                    r = self.rightndx + 1
+                negative_span = l-r
+                if index >= negative_span:
+                    return block, r+index
+                index -= negative_span
+                block = block[LFTLNK]
         raise IndexError("deque index out of range")
-      self.rotate(-index)
-      self.popleft()
-      self.rotate(index)
-    else:
-      index = ~index
-      if index >= length:
-        raise IndexError("deque index out of range")
-      self.rotate(index)
-      self.pop()
-      self.rotate(-index)
 
-  def __reduce_ex__(self, proto):
-    return type(self), (list(self), self.maxlen)
+    def __getitem__(self, index):
+        block, index = self.__getref(index)
+        return block[index]
 
-  __hash__ = None
+    def __setitem__(self, index, value):
+        block, index = self.__getref(index)
+        block[index] = value
 
-  def __copy__(self):
-    return self.__class__(self, self.maxlen)
+    def __delitem__(self, index):
+        length = len(self)
+        if index >= 0:
+            if index >= length:
+                raise IndexError("deque index out of range")
+            self.rotate(-index)
+            self.popleft()
+            self.rotate(index)
+        else:
+            index = ~index
+            if index >= length:
+                raise IndexError("deque index out of range")
+            self.rotate(index)
+            self.pop()
+            self.rotate(-index)
 
-  # XXX make comparison more efficient
-  def __eq__(self, other):
-    if isinstance(other, deque):
-      return list(self) == list(other)
-    else:
-      return NotImplemented
+    def __reduce_ex__(self, proto):
+        return type(self), (list(self), self.maxlen)
 
-  def __ne__(self, other):
-    if isinstance(other, deque):
-      return list(self) != list(other)
-    else:
-      return NotImplemented
+    __hash__ = None
 
-  def __lt__(self, other):
-    if isinstance(other, deque):
-      return list(self) < list(other)
-    else:
-      return NotImplemented
+    def __copy__(self):
+        return self.__class__(self, self.maxlen)
 
-  def __le__(self, other):
-    if isinstance(other, deque):
-      return list(self) <= list(other)
-    else:
-      return NotImplemented
+    # XXX make comparison more efficient
+    def __eq__(self, other):
+        if isinstance(other, deque):
+            return list(self) == list(other)
+        else:
+            return NotImplemented
 
-  def __gt__(self, other):
-    if isinstance(other, deque):
-      return list(self) > list(other)
-    else:
-      return NotImplemented
+    def __ne__(self, other):
+        if isinstance(other, deque):
+            return list(self) != list(other)
+        else:
+            return NotImplemented
 
-  def __ge__(self, other):
-    if isinstance(other, deque):
-      return list(self) >= list(other)
-    else:
-      return NotImplemented
+    def __lt__(self, other):
+        if isinstance(other, deque):
+            return list(self) < list(other)
+        else:
+            return NotImplemented
 
-  def __iadd__(self, other):
-    self.extend(other)
-    return self
+    def __le__(self, other):
+        if isinstance(other, deque):
+            return list(self) <= list(other)
+        else:
+            return NotImplemented
 
+    def __gt__(self, other):
+        if isinstance(other, deque):
+            return list(self) > list(other)
+        else:
+            return NotImplemented
+
+    def __ge__(self, other):
+        if isinstance(other, deque):
+            return list(self) >= list(other)
+        else:
+            return NotImplemented
+
+    def __iadd__(self, other):
+        self.extend(other)
+        return self
 
 class deque_iterator(object):
 
-  def __init__(self, deq, itergen):
-    self.counter = len(deq)
+    def __init__(self, deq, itergen):
+        self.counter = len(deq)
+        def giveup():
+            self.counter = 0
+            raise RuntimeError("deque mutated during iteration")
+        self._gen = itergen(deq.state, giveup)
 
-    def giveup():
-      self.counter = 0
-      raise RuntimeError("deque mutated during iteration")
-    self._gen = itergen(deq.state, giveup)
+    def next(self):
+        res = next(self._gen)
+        self.counter -= 1
+        return res
 
-  def next(self):
-    res = next(self._gen)
-    self.counter -= 1
-    return res
-
-  def __iter__(self):
-    return self
-
+    def __iter__(self):
+        return self
 
 class defaultdict(dict):
 
-  def __init__(self, *args, **kwds):
-    if len(args) > 0:
-      default_factory = args[0]
-      args = args[1:]
-      if not callable(default_factory) and default_factory is not None:
-        raise TypeError("first argument must be callable")
-    else:
-      default_factory = None
-    self.default_factory = default_factory
-    super(defaultdict, self).__init__(*args, **kwds)
+    def __init__(self, *args, **kwds):
+        if len(args) > 0:
+            default_factory = args[0]
+            args = args[1:]
+            if not callable(default_factory) and default_factory is not None:
+                raise TypeError("first argument must be callable")
+        else:
+            default_factory = None
+        self.default_factory = default_factory
+        super(defaultdict, self).__init__(*args, **kwds)
 
-  def __missing__(self, key):
-    # from defaultdict docs
-    if self.default_factory is None:
-      raise KeyError(key)
-    self[key] = value = self.default_factory()
-    return value
+    def __missing__(self, key):
+        # from defaultdict docs
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
 
-  def __repr__(self, recurse=set()):
-    if id(self) in recurse:
-      return "defaultdict(...)"
-    try:
-      recurse.add(id(self))
-      return "defaultdict(%s, %s)" % (repr(self.default_factory), super(defaultdict, self).__repr__())
-    finally:
-      recurse.remove(id(self))
+    def __repr__(self, recurse=set()):
+        if id(self) in recurse:
+            return "defaultdict(...)"
+        try:
+            recurse.add(id(self))
+            return "defaultdict(%s, %s)" % (repr(self.default_factory), super(defaultdict, self).__repr__())
+        finally:
+            recurse.remove(id(self))
 
-  def copy(self):
-    return type(self)(self.default_factory, self)
+    def copy(self):
+        return type(self)(self.default_factory, self)
 
-  def __copy__(self):
-    return self.copy()
+    def __copy__(self):
+        return self.copy()
 
-  def __reduce__(self):
-    """
-    __reduce__ must return a 5-tuple as follows:
+    def __reduce__(self):
+        """
+        __reduce__ must return a 5-tuple as follows:
 
-       - factory function
-       - tuple of args for the factory function
-       - additional state (here None)
-       - sequence iterator (here None)
-       - dictionary iterator (yielding successive (key, value) pairs
+           - factory function
+           - tuple of args for the factory function
+           - additional state (here None)
+           - sequence iterator (here None)
+           - dictionary iterator (yielding successive (key, value) pairs
 
-       This API is used by pickle.py and copy.py.
-    """
-    return (type(self), (self.default_factory,), None, None, self.iteritems())
+           This API is used by pickle.py and copy.py.
+        """
+        return (type(self), (self.default_factory,), None, None, self.iteritems())
+

--- a/third_party/pypy/_collections.py
+++ b/third_party/pypy/_collections.py
@@ -1,0 +1,440 @@
+"""High performance data structures
+"""
+#
+# Copied and completed from the sandbox of CPython
+#   (nondist/sandbox/collections/pydeque.py rev 1.1, Raymond Hettinger)
+#
+
+# Note that PyPy also contains a built-in module '_collections' which will hide
+# this one if compiled in.
+
+# try:
+#     from threading import _get_ident as _thread_ident
+# except ImportError:
+
+import thread
+_thread_ident = thread.get_ident
+
+
+n = 30
+LFTLNK = n
+RGTLNK = n + 1
+BLOCKSIZ = n + 2
+
+# The deque's size limit is d.maxlen.  The limit can be zero or positive, or
+# None.  After an item is added to a deque, we check to see if the size has
+# grown past the limit. If it has, we get the size back down to the limit by
+# popping an item off of the opposite end.  The methods that can trigger this
+# are append(), appendleft(), extend(), and extendleft().
+
+
+class deque(object):
+
+  def __new__(cls, iterable=(), *args, **kw):
+    self = super(deque, cls).__new__(cls)
+    self.clear()
+    return self
+
+  def __init__(self, iterable=(), maxlen=None):
+    self.clear()
+    if maxlen is not None:
+      if maxlen < 0:
+        raise ValueError("maxlen must be non-negative")
+    self._maxlen = maxlen
+    add = self.append
+    for elem in iterable:
+      add(elem)
+
+  @property
+  def maxlen(self):
+    return self._maxlen
+  # TODO: Make this a decorator once they're implemented.
+  maxlen = property(maxlen)
+
+  def clear(self):
+    self.right = self.left = [None] * BLOCKSIZ
+    self.rightndx = n // 2   # points to last written element
+    self.leftndx = n // 2 + 1
+    self.length = 0
+    self.state = 0
+
+  def append(self, x):
+    self.state += 1
+    self.rightndx += 1
+    if self.rightndx == n:
+      newblock = [None] * BLOCKSIZ
+      self.right[RGTLNK] = newblock
+      newblock[LFTLNK] = self.right
+      self.right = newblock
+      self.rightndx = 0
+    self.length += 1
+    self.right[self.rightndx] = x
+    if self.maxlen is not None and self.length > self.maxlen:
+      self.popleft()
+
+  def appendleft(self, x):
+    self.state += 1
+    self.leftndx -= 1
+    if self.leftndx == -1:
+      newblock = [None] * BLOCKSIZ
+      self.left[LFTLNK] = newblock
+      newblock[RGTLNK] = self.left
+      self.left = newblock
+      self.leftndx = n - 1
+    self.length += 1
+    self.left[self.leftndx] = x
+    if self.maxlen is not None and self.length > self.maxlen:
+      self.pop()
+
+  def extend(self, iterable):
+    if iterable is self:
+      iterable = list(iterable)
+    for elem in iterable:
+      self.append(elem)
+
+  def extendleft(self, iterable):
+    if iterable is self:
+      iterable = list(iterable)
+    for elem in iterable:
+      self.appendleft(elem)
+
+  def pop(self):
+    if self.left is self.right and self.leftndx > self.rightndx:
+      raise IndexError("pop from an empty deque")
+    x = self.right[self.rightndx]
+    self.right[self.rightndx] = None
+    self.length -= 1
+    self.rightndx -= 1
+    self.state += 1
+    if self.rightndx == -1:
+      prevblock = self.right[LFTLNK]
+      if prevblock is None:
+        # the deque has become empty; recenter instead of freeing block
+        self.rightndx = n // 2
+        self.leftndx = n // 2 + 1
+      else:
+        prevblock[RGTLNK] = None
+        self.right[LFTLNK] = None
+        self.right = prevblock
+        self.rightndx = n - 1
+    return x
+
+  def popleft(self):
+    if self.left is self.right and self.leftndx > self.rightndx:
+      raise IndexError("pop from an empty deque")
+    x = self.left[self.leftndx]
+    self.left[self.leftndx] = None
+    self.length -= 1
+    self.leftndx += 1
+    self.state += 1
+    if self.leftndx == n:
+      prevblock = self.left[RGTLNK]
+      if prevblock is None:
+        # the deque has become empty; recenter instead of freeing block
+        self.rightndx = n // 2
+        self.leftndx = n // 2 + 1
+      else:
+        prevblock[LFTLNK] = None
+        self.left[RGTLNK] = None
+        self.left = prevblock
+        self.leftndx = 0
+    return x
+
+  def count(self, value):
+    c = 0
+    for item in self:
+      if item == value:
+        c += 1
+    return c
+
+  def remove(self, value):
+    # Need to defend mutating or failing comparisons
+    i = 0
+    try:
+      for i in range(len(self)):
+        if self[0] == value:
+          self.popleft()
+          return
+        self.append(self.popleft())
+      i += 1
+      raise ValueError("deque.remove(x): x not in deque")
+    finally:
+      self.rotate(i)
+
+  def rotate(self, n=1):
+    length = len(self)
+    if length <= 1:
+      return
+    halflen = length >> 1
+    if n > halflen or n < -halflen:
+      n %= length
+      if n > halflen:
+        n -= length
+      elif n < -halflen:
+        n += length
+    while n > 0:
+      self.appendleft(self.pop())
+      n -= 1
+    while n < 0:
+      self.append(self.popleft())
+      n += 1
+
+  def reverse(self):
+    "reverse *IN PLACE*"
+    leftblock = self.left
+    rightblock = self.right
+    leftindex = self.leftndx
+    rightindex = self.rightndx
+    for i in range(self.length // 2):
+      # Validate that pointers haven't met in the middle
+      assert leftblock != rightblock or leftindex < rightindex
+
+      # Swap
+      (rightblock[rightindex], leftblock[leftindex]) = (
+          leftblock[leftindex], rightblock[rightindex])
+
+      # Advance left block/index pair
+      leftindex += 1
+      if leftindex == n:
+        leftblock = leftblock[RGTLNK]
+        assert leftblock is not None
+        leftindex = 0
+
+      # Step backwards with the right block/index pair
+      rightindex -= 1
+      if rightindex == -1:
+        rightblock = rightblock[LFTLNK]
+        assert rightblock is not None
+        rightindex = n - 1
+
+  def __repr__(self):
+    threadlocalattr = '__repr' + str(_thread_ident())
+    if threadlocalattr in self.__dict__:
+      return 'deque([...])'
+    else:
+      self.__dict__[threadlocalattr] = True
+      try:
+        if self.maxlen is not None:
+          return 'deque(%r, maxlen=%s)' % (list(self), self.maxlen)
+        else:
+          return 'deque(%r)' % (list(self),)
+      finally:
+        del self.__dict__[threadlocalattr]
+
+  def __iter__(self):
+    return deque_iterator(self, self._iter_impl)
+
+  def _iter_impl(self, original_state, giveup):
+    if self.state != original_state:
+      giveup()
+    block = self.left
+    while block:
+      l, r = 0, n
+      if block is self.left:
+        l = self.leftndx
+      if block is self.right:
+        r = self.rightndx + 1
+      for elem in block[l:r]:
+        yield elem
+        if self.state != original_state:
+          giveup()
+      block = block[RGTLNK]
+
+  def __reversed__(self):
+    return deque_iterator(self, self._reversed_impl)
+
+  def _reversed_impl(self, original_state, giveup):
+    if self.state != original_state:
+      giveup()
+    block = self.right
+    while block:
+      l, r = 0, n
+      if block is self.left:
+        l = self.leftndx
+      if block is self.right:
+        r = self.rightndx + 1
+      for elem in reversed(block[l:r]):
+        yield elem
+        if self.state != original_state:
+          giveup()
+      block = block[LFTLNK]
+
+  def __len__(self):
+    #sum = 0
+    #block = self.left
+    # while block:
+    #    sum += n
+    #    block = block[RGTLNK]
+    # return sum + self.rightndx - self.leftndx + 1 - n
+    return self.length
+
+  def __getref(self, index):
+    if index >= 0:
+      block = self.left
+      while block:
+        l, r = 0, n
+        if block is self.left:
+          l = self.leftndx
+        if block is self.right:
+          r = self.rightndx + 1
+        span = r - l
+        if index < span:
+          return block, l + index
+        index -= span
+        block = block[RGTLNK]
+    else:
+      block = self.right
+      while block:
+        l, r = 0, n
+        if block is self.left:
+          l = self.leftndx
+        if block is self.right:
+          r = self.rightndx + 1
+        negative_span = l - r
+        if index >= negative_span:
+          return block, r + index
+        index -= negative_span
+        block = block[LFTLNK]
+    raise IndexError("deque index out of range")
+
+  def __getitem__(self, index):
+    block, index = self.__getref(index)
+    return block[index]
+
+  def __setitem__(self, index, value):
+    block, index = self.__getref(index)
+    block[index] = value
+
+  def __delitem__(self, index):
+    length = len(self)
+    if index >= 0:
+      if index >= length:
+        raise IndexError("deque index out of range")
+      self.rotate(-index)
+      self.popleft()
+      self.rotate(index)
+    else:
+      index = ~index
+      if index >= length:
+        raise IndexError("deque index out of range")
+      self.rotate(index)
+      self.pop()
+      self.rotate(-index)
+
+  def __reduce_ex__(self, proto):
+    return type(self), (list(self), self.maxlen)
+
+  __hash__ = None
+
+  def __copy__(self):
+    return self.__class__(self, self.maxlen)
+
+  # XXX make comparison more efficient
+  def __eq__(self, other):
+    if isinstance(other, deque):
+      return list(self) == list(other)
+    else:
+      return NotImplemented
+
+  def __ne__(self, other):
+    if isinstance(other, deque):
+      return list(self) != list(other)
+    else:
+      return NotImplemented
+
+  def __lt__(self, other):
+    if isinstance(other, deque):
+      return list(self) < list(other)
+    else:
+      return NotImplemented
+
+  def __le__(self, other):
+    if isinstance(other, deque):
+      return list(self) <= list(other)
+    else:
+      return NotImplemented
+
+  def __gt__(self, other):
+    if isinstance(other, deque):
+      return list(self) > list(other)
+    else:
+      return NotImplemented
+
+  def __ge__(self, other):
+    if isinstance(other, deque):
+      return list(self) >= list(other)
+    else:
+      return NotImplemented
+
+  def __iadd__(self, other):
+    self.extend(other)
+    return self
+
+
+class deque_iterator(object):
+
+  def __init__(self, deq, itergen):
+    self.counter = len(deq)
+
+    def giveup():
+      self.counter = 0
+      raise RuntimeError("deque mutated during iteration")
+    self._gen = itergen(deq.state, giveup)
+
+  def next(self):
+    res = next(self._gen)
+    self.counter -= 1
+    return res
+
+  def __iter__(self):
+    return self
+
+
+class defaultdict(dict):
+
+  def __init__(self, *args, **kwds):
+    if len(args) > 0:
+      default_factory = args[0]
+      args = args[1:]
+      if not callable(default_factory) and default_factory is not None:
+        raise TypeError("first argument must be callable")
+    else:
+      default_factory = None
+    self.default_factory = default_factory
+    super(defaultdict, self).__init__(*args, **kwds)
+
+  def __missing__(self, key):
+    # from defaultdict docs
+    if self.default_factory is None:
+      raise KeyError(key)
+    self[key] = value = self.default_factory()
+    return value
+
+  def __repr__(self, recurse=set()):
+    if id(self) in recurse:
+      return "defaultdict(...)"
+    try:
+      recurse.add(id(self))
+      return "defaultdict(%s, %s)" % (repr(self.default_factory), super(defaultdict, self).__repr__())
+    finally:
+      recurse.remove(id(self))
+
+  def copy(self):
+    return type(self)(self.default_factory, self)
+
+  def __copy__(self):
+    return self.copy()
+
+  def __reduce__(self):
+    """
+    __reduce__ must return a 5-tuple as follows:
+
+       - factory function
+       - tuple of args for the factory function
+       - additional state (here None)
+       - sequence iterator (here None)
+       - dictionary iterator (yielding successive (key, value) pairs
+
+       This API is used by pickle.py and copy.py.
+    """
+    return (type(self), (self.default_factory,), None, None, self.iteritems())

--- a/third_party/stdlib/collections.py
+++ b/third_party/stdlib/collections.py
@@ -10,7 +10,7 @@ list, set, and tuple.
 
 '''
 
-__all__ = ['Counter', 'namedtuple', 'OrderedDict'] # 'deque', 'defaultdict',
+__all__ = ['Counter', 'OrderedDict', 'deque']  # 'namedtuple', 'defaultdict',
 # For bootstrapping reasons, the collection ABCs are defined in _abcoll.py.
 # They should however be considered an integral part of collections.py.
 import _abcoll
@@ -20,7 +20,7 @@ for name in _abcoll.__all__:
 
 import _collections
 deque = _collections.deque
-#defaultdict = _collections.defaultdict
+# defaultdict = _collections.defaultdict
 import operator
 _itemgetter = operator.itemgetter
 _eq = operator.eq
@@ -34,228 +34,228 @@ _chain = itertools.chain
 _starmap = itertools.starmap
 _imap = itertools.imap
 
-#try:
+# try:
 import thread
 _get_ident = thread.get_ident
-#except ImportError:
+# except ImportError:
 #    from dummy_thread import get_ident as _get_ident
 
 
 ################################################################################
-### OrderedDict
+# OrderedDict
 ################################################################################
 
 class OrderedDict(dict):
-    'Dictionary that remembers insertion order'
-    # An inherited dict maps keys to values.
-    # The inherited dict provides __getitem__, __len__, __contains__, and get.
-    # The remaining methods are order-aware.
-    # Big-O running times for all methods are the same as regular dictionaries.
+  'Dictionary that remembers insertion order'
+  # An inherited dict maps keys to values.
+  # The inherited dict provides __getitem__, __len__, __contains__, and get.
+  # The remaining methods are order-aware.
+  # Big-O running times for all methods are the same as regular dictionaries.
 
-    # The internal self.__map dict maps keys to links in a doubly linked list.
-    # The circular doubly linked list starts and ends with a sentinel element.
-    # The sentinel element never gets deleted (this simplifies the algorithm).
-    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+  # The internal self.__map dict maps keys to links in a doubly linked list.
+  # The circular doubly linked list starts and ends with a sentinel element.
+  # The sentinel element never gets deleted (this simplifies the algorithm).
+  # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
 
-    def __init__(*args, **kwds):
-        '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries, but keyword arguments are not recommended because
-        their insertion order is arbitrary.
+  def __init__(*args, **kwds):
+    '''Initialize an ordered dictionary.  The signature is the same as
+    regular dictionaries, but keyword arguments are not recommended because
+    their insertion order is arbitrary.
 
-        '''
-        if not args:
-            raise TypeError("descriptor '__init__' of 'OrderedDict' object "
-                            "needs an argument")
-        self = args[0]
-        args = args[1:]
-        if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        try:
-            self.__root
-        except AttributeError:
-            self.__root = root = []                     # sentinel node
-            root[:] = [root, root, None]
-            self.__map = {}
-        self.__update(*args, **kwds)
+    '''
+    if not args:
+      raise TypeError("descriptor '__init__' of 'OrderedDict' object "
+                      "needs an argument")
+    self = args[0]
+    args = args[1:]
+    if len(args) > 1:
+      raise TypeError('expected at most 1 arguments, got %d' % len(args))
+    try:
+      self.__root
+    except AttributeError:
+      self.__root = root = []                     # sentinel node
+      root[:] = [root, root, None]
+      self.__map = {}
+    self.__update(*args, **kwds)
 
-    def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
-        'od.__setitem__(i, y) <==> od[i]=y'
-        # Setting a new item creates a new link at the end of the linked list,
-        # and the inherited dictionary is updated with the new key/value pair.
-        if key not in self:
-            root = self.__root
-            last = root[0]
-            last[1] = root[0] = self.__map[key] = [last, root, key]
-        return dict_setitem(self, key, value)
+  def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+    'od.__setitem__(i, y) <==> od[i]=y'
+    # Setting a new item creates a new link at the end of the linked list,
+    # and the inherited dictionary is updated with the new key/value pair.
+    if key not in self:
+      root = self.__root
+      last = root[0]
+      last[1] = root[0] = self.__map[key] = [last, root, key]
+    return dict_setitem(self, key, value)
 
-    def __delitem__(self, key, dict_delitem=dict.__delitem__):
-        'od.__delitem__(y) <==> del od[y]'
-        # Deleting an existing item uses self.__map to find the link which gets
-        # removed by updating the links in the predecessor and successor nodes.
-        dict_delitem(self, key)
-        link_prev, link_next, _ = self.__map.pop(key)
-        link_prev[1] = link_next                        # update link_prev[NEXT]
-        link_next[0] = link_prev                        # update link_next[PREV]
+  def __delitem__(self, key, dict_delitem=dict.__delitem__):
+    'od.__delitem__(y) <==> del od[y]'
+    # Deleting an existing item uses self.__map to find the link which gets
+    # removed by updating the links in the predecessor and successor nodes.
+    dict_delitem(self, key)
+    link_prev, link_next, _ = self.__map.pop(key)
+    link_prev[1] = link_next                        # update link_prev[NEXT]
+    link_next[0] = link_prev                        # update link_next[PREV]
 
-    def __iter__(self):
-        'od.__iter__() <==> iter(od)'
-        # Traverse the linked list in order.
-        root = self.__root
-        curr = root[1]                                  # start at the first node
-        while curr is not root:
-            yield curr[2]                               # yield the curr[KEY]
-            curr = curr[1]                              # move to next node
+  def __iter__(self):
+    'od.__iter__() <==> iter(od)'
+    # Traverse the linked list in order.
+    root = self.__root
+    curr = root[1]                                  # start at the first node
+    while curr is not root:
+      yield curr[2]                               # yield the curr[KEY]
+      curr = curr[1]                              # move to next node
 
-    def __reversed__(self):
-        'od.__reversed__() <==> reversed(od)'
-        # Traverse the linked list in reverse order.
-        root = self.__root
-        curr = root[0]                                  # start at the last node
-        while curr is not root:
-            yield curr[2]                               # yield the curr[KEY]
-            curr = curr[0]                              # move to previous node
+  def __reversed__(self):
+    'od.__reversed__() <==> reversed(od)'
+    # Traverse the linked list in reverse order.
+    root = self.__root
+    curr = root[0]                                  # start at the last node
+    while curr is not root:
+      yield curr[2]                               # yield the curr[KEY]
+      curr = curr[0]                              # move to previous node
 
-    def clear(self):
-        'od.clear() -> None.  Remove all items from od.'
-        root = self.__root
-        root[:] = [root, root, None]
-        self.__map.clear()
-        dict.clear(self)
+  def clear(self):
+    'od.clear() -> None.  Remove all items from od.'
+    root = self.__root
+    root[:] = [root, root, None]
+    self.__map.clear()
+    dict.clear(self)
 
-    # -- the following methods do not depend on the internal structure --
+  # -- the following methods do not depend on the internal structure --
 
-    def keys(self):
-        'od.keys() -> list of keys in od'
-        return list(self)
+  def keys(self):
+    'od.keys() -> list of keys in od'
+    return list(self)
 
-    def values(self):
-        'od.values() -> list of values in od'
-        return [self[key] for key in self]
+  def values(self):
+    'od.values() -> list of values in od'
+    return [self[key] for key in self]
 
-    def items(self):
-        'od.items() -> list of (key, value) pairs in od'
-        return [(key, self[key]) for key in self]
+  def items(self):
+    'od.items() -> list of (key, value) pairs in od'
+    return [(key, self[key]) for key in self]
 
-    def iterkeys(self):
-        'od.iterkeys() -> an iterator over the keys in od'
-        return iter(self)
+  def iterkeys(self):
+    'od.iterkeys() -> an iterator over the keys in od'
+    return iter(self)
 
-    def itervalues(self):
-        'od.itervalues -> an iterator over the values in od'
-        for k in self:
-            yield self[k]
+  def itervalues(self):
+    'od.itervalues -> an iterator over the values in od'
+    for k in self:
+      yield self[k]
 
-    def iteritems(self):
-        'od.iteritems -> an iterator over the (key, value) pairs in od'
-        for k in self:
-            yield (k, self[k])
+  def iteritems(self):
+    'od.iteritems -> an iterator over the (key, value) pairs in od'
+    for k in self:
+      yield (k, self[k])
 
-    update = MutableMapping.update
+  update = MutableMapping.update
 
-    __update = update # let subclasses override update without breaking __init__
+  __update = update  # let subclasses override update without breaking __init__
 
-    __marker = object()
+  __marker = object()
 
-    def pop(self, key, default=__marker):
-        '''od.pop(k[,d]) -> v, remove specified key and return the corresponding
-        value.  If key is not found, d is returned if given, otherwise KeyError
-        is raised.
+  def pop(self, key, default=__marker):
+    '''od.pop(k[,d]) -> v, remove specified key and return the corresponding
+    value.  If key is not found, d is returned if given, otherwise KeyError
+    is raised.
 
-        '''
-        if key in self:
-            result = self[key]
-            del self[key]
-            return result
-        if default is self.__marker:
-            raise KeyError(key)
-        return default
+    '''
+    if key in self:
+      result = self[key]
+      del self[key]
+      return result
+    if default is self.__marker:
+      raise KeyError(key)
+    return default
 
-    def setdefault(self, key, default=None):
-        'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
-        if key in self:
-            return self[key]
-        self[key] = default
-        return default
+  def setdefault(self, key, default=None):
+    'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+    if key in self:
+      return self[key]
+    self[key] = default
+    return default
 
-    def popitem(self, last=True):
-        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
-        Pairs are returned in LIFO order if last is true or FIFO order if false.
+  def popitem(self, last=True):
+    '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+    Pairs are returned in LIFO order if last is true or FIFO order if false.
 
-        '''
-        if not self:
-            raise KeyError('dictionary is empty')
-        key = next(reversed(self) if last else iter(self))
-        value = self.pop(key)
-        return key, value
+    '''
+    if not self:
+      raise KeyError('dictionary is empty')
+    key = next(reversed(self) if last else iter(self))
+    value = self.pop(key)
+    return key, value
 
-    def __repr__(self, _repr_running={}):
-        'od.__repr__() <==> repr(od)'
-        call_key = id(self), _get_ident()
-        if call_key in _repr_running:
-            return '...'
-        _repr_running[call_key] = 1
-        try:
-            if not self:
-                return '%s()' % (self.__class__.__name__,)
-            return '%s(%r)' % (self.__class__.__name__, self.items())
-        finally:
-            del _repr_running[call_key]
+  def __repr__(self, _repr_running={}):
+    'od.__repr__() <==> repr(od)'
+    call_key = id(self), _get_ident()
+    if call_key in _repr_running:
+      return '...'
+    _repr_running[call_key] = 1
+    try:
+      if not self:
+        return '%s()' % (self.__class__.__name__,)
+      return '%s(%r)' % (self.__class__.__name__, self.items())
+    finally:
+      del _repr_running[call_key]
 
-    def __reduce__(self):
-        'Return state information for pickling'
-        items = [[k, self[k]] for k in self]
-        inst_dict = vars(self).copy()
-        for k in vars(OrderedDict()):
-            inst_dict.pop(k, None)
-        if inst_dict:
-            return (self.__class__, (items,), inst_dict)
-        return self.__class__, (items,)
+  def __reduce__(self):
+    'Return state information for pickling'
+    items = [[k, self[k]] for k in self]
+    inst_dict = vars(self).copy()
+    for k in vars(OrderedDict()):
+      inst_dict.pop(k, None)
+    if inst_dict:
+      return (self.__class__, (items,), inst_dict)
+    return self.__class__, (items,)
 
-    def copy(self):
-        'od.copy() -> a shallow copy of od'
-        return self.__class__(self)
+  def copy(self):
+    'od.copy() -> a shallow copy of od'
+    return self.__class__(self)
 
-    @classmethod
-    def fromkeys(cls, iterable, value=None):
-        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.
-        If not specified, the value defaults to None.
+  @classmethod
+  def fromkeys(cls, iterable, value=None):
+    '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.
+    If not specified, the value defaults to None.
 
-        '''
-        self = cls()
-        for key in iterable:
-            self[key] = value
-        return self
+    '''
+    self = cls()
+    for key in iterable:
+      self[key] = value
+    return self
 
-    def __eq__(self, other):
-        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
-        while comparison to a regular mapping is order-insensitive.
+  def __eq__(self, other):
+    '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+    while comparison to a regular mapping is order-insensitive.
 
-        '''
-        if isinstance(other, OrderedDict):
-            return dict.__eq__(self, other) and all(_imap(_eq, self, other))
-        return dict.__eq__(self, other)
+    '''
+    if isinstance(other, OrderedDict):
+      return dict.__eq__(self, other) and all(_imap(_eq, self, other))
+    return dict.__eq__(self, other)
 
-    def __ne__(self, other):
-        'od.__ne__(y) <==> od!=y'
-        return not self == other
+  def __ne__(self, other):
+    'od.__ne__(y) <==> od!=y'
+    return not self == other
 
-    # -- the following methods support python 3.x style dictionary views --
+  # -- the following methods support python 3.x style dictionary views --
 
-    def viewkeys(self):
-        "od.viewkeys() -> a set-like object providing a view on od's keys"
-        return KeysView(self)
+  def viewkeys(self):
+    "od.viewkeys() -> a set-like object providing a view on od's keys"
+    return KeysView(self)
 
-    def viewvalues(self):
-        "od.viewvalues() -> an object providing a view on od's values"
-        return ValuesView(self)
+  def viewvalues(self):
+    "od.viewvalues() -> an object providing a view on od's values"
+    return ValuesView(self)
 
-    def viewitems(self):
-        "od.viewitems() -> a set-like object providing a view on od's items"
-        return ItemsView(self)
+  def viewitems(self):
+    "od.viewitems() -> a set-like object providing a view on od's items"
+    return ItemsView(self)
 
 
 ################################################################################
-### namedtuple
+# namedtuple
 ################################################################################
 
 _class_template = '''\
@@ -312,7 +312,7 @@ _field_template = '''\
     {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
 '''
 
-#def namedtuple(typename, field_names, verbose=False, rename=False):
+# def namedtuple(typename, field_names, verbose=False, rename=False):
 #    """Returns a new subclass of tuple with named fields.
 #
 #    >>> Point = namedtuple('Point', ['x', 'y'])
@@ -411,313 +411,314 @@ _field_template = '''\
 
 
 ########################################################################
-###  Counter
+# Counter
 ########################################################################
 
 class Counter(dict):
-    '''Dict subclass for counting hashable items.  Sometimes called a bag
-    or multiset.  Elements are stored as dictionary keys and their counts
-    are stored as dictionary values.
+  '''Dict subclass for counting hashable items.  Sometimes called a bag
+  or multiset.  Elements are stored as dictionary keys and their counts
+  are stored as dictionary values.
 
-    >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
+  >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
 
-    >>> c.most_common(3)                # three most common elements
-    [('a', 5), ('b', 4), ('c', 3)]
-    >>> sorted(c)                       # list all unique elements
-    ['a', 'b', 'c', 'd', 'e']
-    >>> ''.join(sorted(c.elements()))   # list elements with repetitions
-    'aaaaabbbbcccdde'
-    >>> sum(c.values())                 # total of all counts
-    15
+  >>> c.most_common(3)                # three most common elements
+  [('a', 5), ('b', 4), ('c', 3)]
+  >>> sorted(c)                       # list all unique elements
+  ['a', 'b', 'c', 'd', 'e']
+  >>> ''.join(sorted(c.elements()))   # list elements with repetitions
+  'aaaaabbbbcccdde'
+  >>> sum(c.values())                 # total of all counts
+  15
 
-    >>> c['a']                          # count of letter 'a'
-    5
-    >>> for elem in 'shazam':           # update counts from an iterable
-    ...     c[elem] += 1                # by adding 1 to each element's count
-    >>> c['a']                          # now there are seven 'a'
-    7
-    >>> del c['b']                      # remove all 'b'
-    >>> c['b']                          # now there are zero 'b'
-    0
+  >>> c['a']                          # count of letter 'a'
+  5
+  >>> for elem in 'shazam':           # update counts from an iterable
+  ...     c[elem] += 1                # by adding 1 to each element's count
+  >>> c['a']                          # now there are seven 'a'
+  7
+  >>> del c['b']                      # remove all 'b'
+  >>> c['b']                          # now there are zero 'b'
+  0
 
-    >>> d = Counter('simsalabim')       # make another counter
-    >>> c.update(d)                     # add in the second counter
-    >>> c['a']                          # now there are nine 'a'
-    9
+  >>> d = Counter('simsalabim')       # make another counter
+  >>> c.update(d)                     # add in the second counter
+  >>> c['a']                          # now there are nine 'a'
+  9
 
-    >>> c.clear()                       # empty the counter
-    >>> c
-    Counter()
+  >>> c.clear()                       # empty the counter
+  >>> c
+  Counter()
 
-    Note:  If a count is set to zero or reduced to zero, it will remain
-    in the counter until the entry is deleted or the counter is cleared:
+  Note:  If a count is set to zero or reduced to zero, it will remain
+  in the counter until the entry is deleted or the counter is cleared:
 
-    >>> c = Counter('aaabbc')
-    >>> c['b'] -= 2                     # reduce the count of 'b' by two
-    >>> c.most_common()                 # 'b' is still in, but its count is zero
-    [('a', 3), ('c', 1), ('b', 0)]
+  >>> c = Counter('aaabbc')
+  >>> c['b'] -= 2                     # reduce the count of 'b' by two
+  >>> c.most_common()                 # 'b' is still in, but its count is zero
+  [('a', 3), ('c', 1), ('b', 0)]
+
+  '''
+  # References:
+  #   http://en.wikipedia.org/wiki/Multiset
+  #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
+  #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
+  #   http://code.activestate.com/recipes/259174/
+  #   Knuth, TAOCP Vol. II section 4.6.3
+
+  def __init__(*args, **kwds):
+    '''Create a new, empty Counter object.  And if given, count elements
+    from an input iterable.  Or, initialize the count from another mapping
+    of elements to their counts.
+
+    >>> c = Counter()                           # a new, empty counter
+    >>> c = Counter('gallahad')                 # a new counter from an iterable
+    >>> c = Counter({'a': 4, 'b': 2})           # a new counter from a mapping
+    >>> c = Counter(a=4, b=2)                   # a new counter from keyword args
 
     '''
-    # References:
-    #   http://en.wikipedia.org/wiki/Multiset
-    #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
-    #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
-    #   http://code.activestate.com/recipes/259174/
-    #   Knuth, TAOCP Vol. II section 4.6.3
+    if not args:
+      raise TypeError("descriptor '__init__' of 'Counter' object "
+                      "needs an argument")
+    self = args[0]
+    args = args[1:]
+    if len(args) > 1:
+      raise TypeError('expected at most 1 arguments, got %d' % len(args))
+    super(Counter, self).__init__()
+    self.update(*args, **kwds)
 
-    def __init__(*args, **kwds):
-        '''Create a new, empty Counter object.  And if given, count elements
-        from an input iterable.  Or, initialize the count from another mapping
-        of elements to their counts.
+  def __missing__(self, key):
+    'The count of elements not in the Counter is zero.'
+    # Needed so that self[missing_item] does not raise KeyError
+    return 0
 
-        >>> c = Counter()                           # a new, empty counter
-        >>> c = Counter('gallahad')                 # a new counter from an iterable
-        >>> c = Counter({'a': 4, 'b': 2})           # a new counter from a mapping
-        >>> c = Counter(a=4, b=2)                   # a new counter from keyword args
+  def most_common(self, n=None):
+    '''List the n most common elements and their counts from the most
+    common to the least.  If n is None, then list all element counts.
 
-        '''
-        if not args:
-            raise TypeError("descriptor '__init__' of 'Counter' object "
-                            "needs an argument")
-        self = args[0]
-        args = args[1:]
-        if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        super(Counter, self).__init__()
-        self.update(*args, **kwds)
+    >>> Counter('abcdeabcdabcaba').most_common(3)
+    [('a', 5), ('b', 4), ('c', 3)]
 
-    def __missing__(self, key):
-        'The count of elements not in the Counter is zero.'
-        # Needed so that self[missing_item] does not raise KeyError
-        return 0
+    '''
+    # Emulate Bag.sortedByCount from Smalltalk
+    if n is None:
+      return sorted(self.iteritems(), key=_itemgetter(1), reverse=True)
+    return _heapq.nlargest(n, self.iteritems(), key=_itemgetter(1))
 
-    def most_common(self, n=None):
-        '''List the n most common elements and their counts from the most
-        common to the least.  If n is None, then list all element counts.
+  def elements(self):
+    '''Iterator over elements repeating each as many times as its count.
 
-        >>> Counter('abcdeabcdabcaba').most_common(3)
-        [('a', 5), ('b', 4), ('c', 3)]
+    >>> c = Counter('ABCABC')
+    >>> sorted(c.elements())
+    ['A', 'A', 'B', 'B', 'C', 'C']
 
-        '''
-        # Emulate Bag.sortedByCount from Smalltalk
-        if n is None:
-            return sorted(self.iteritems(), key=_itemgetter(1), reverse=True)
-        return _heapq.nlargest(n, self.iteritems(), key=_itemgetter(1))
+    # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
+    >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
+    >>> product = 1
+    >>> for factor in prime_factors.elements():     # loop over factors
+    ...     product *= factor                       # and multiply them
+    >>> product
+    1836
 
-    def elements(self):
-        '''Iterator over elements repeating each as many times as its count.
+    Note, if an element's count has been set to zero or is a negative
+    number, elements() will ignore it.
 
-        >>> c = Counter('ABCABC')
-        >>> sorted(c.elements())
-        ['A', 'A', 'B', 'B', 'C', 'C']
+    '''
+    # Emulate Bag.do from Smalltalk and Multiset.begin from C++.
+    return _chain.from_iterable(_starmap(_repeat, self.iteritems()))
 
-        # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
-        >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
-        >>> product = 1
-        >>> for factor in prime_factors.elements():     # loop over factors
-        ...     product *= factor                       # and multiply them
-        >>> product
-        1836
+  # Override dict methods where necessary
 
-        Note, if an element's count has been set to zero or is a negative
-        number, elements() will ignore it.
+  @classmethod
+  def fromkeys(cls, iterable, v=None):
+    # There is no equivalent method for counters because setting v=1
+    # means that no element can have a count greater than one.
+    raise NotImplementedError(
+        'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.')
 
-        '''
-        # Emulate Bag.do from Smalltalk and Multiset.begin from C++.
-        return _chain.from_iterable(_starmap(_repeat, self.iteritems()))
+  def update(*args, **kwds):
+    '''Like dict.update() but add counts instead of replacing them.
 
-    # Override dict methods where necessary
+    Source can be an iterable, a dictionary, or another Counter instance.
 
-    @classmethod
-    def fromkeys(cls, iterable, v=None):
-        # There is no equivalent method for counters because setting v=1
-        # means that no element can have a count greater than one.
-        raise NotImplementedError(
-            'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.')
+    >>> c = Counter('which')
+    >>> c.update('witch')           # add elements from another iterable
+    >>> d = Counter('watch')
+    >>> c.update(d)                 # add elements from another counter
+    >>> c['h']                      # four 'h' in which, witch, and watch
+    4
 
-    def update(*args, **kwds):
-        '''Like dict.update() but add counts instead of replacing them.
+    '''
+    # The regular dict.update() operation makes no sense here because the
+    # replace behavior results in the some of original untouched counts
+    # being mixed-in with all of the other counts for a mismash that
+    # doesn't have a straight-forward interpretation in most counting
+    # contexts.  Instead, we implement straight-addition.  Both the inputs
+    # and outputs are allowed to contain zero and negative counts.
 
-        Source can be an iterable, a dictionary, or another Counter instance.
+    if not args:
+      raise TypeError("descriptor 'update' of 'Counter' object "
+                      "needs an argument")
+    self = args[0]
+    args = args[1:]
+    if len(args) > 1:
+      raise TypeError('expected at most 1 arguments, got %d' % len(args))
+    iterable = args[0] if args else None
+    if iterable is not None:
+      if isinstance(iterable, Mapping):
+        if self:
+          self_get = self.get
+          for elem, count in iterable.iteritems():
+            self[elem] = self_get(elem, 0) + count
+        else:
+          # fast path when counter is empty
+          super(Counter, self).update(iterable)
+      else:
+        self_get = self.get
+        for elem in iterable:
+          self[elem] = self_get(elem, 0) + 1
+    if kwds:
+      self.update(kwds)
 
-        >>> c = Counter('which')
-        >>> c.update('witch')           # add elements from another iterable
-        >>> d = Counter('watch')
-        >>> c.update(d)                 # add elements from another counter
-        >>> c['h']                      # four 'h' in which, witch, and watch
-        4
+  def subtract(*args, **kwds):
+    '''Like dict.update() but subtracts counts instead of replacing them.
+    Counts can be reduced below zero.  Both the inputs and outputs are
+    allowed to contain zero and negative counts.
 
-        '''
-        # The regular dict.update() operation makes no sense here because the
-        # replace behavior results in the some of original untouched counts
-        # being mixed-in with all of the other counts for a mismash that
-        # doesn't have a straight-forward interpretation in most counting
-        # contexts.  Instead, we implement straight-addition.  Both the inputs
-        # and outputs are allowed to contain zero and negative counts.
+    Source can be an iterable, a dictionary, or another Counter instance.
 
-        if not args:
-            raise TypeError("descriptor 'update' of 'Counter' object "
-                            "needs an argument")
-        self = args[0]
-        args = args[1:]
-        if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        iterable = args[0] if args else None
-        if iterable is not None:
-            if isinstance(iterable, Mapping):
-                if self:
-                    self_get = self.get
-                    for elem, count in iterable.iteritems():
-                        self[elem] = self_get(elem, 0) + count
-                else:
-                    super(Counter, self).update(iterable) # fast path when counter is empty
-            else:
-                self_get = self.get
-                for elem in iterable:
-                    self[elem] = self_get(elem, 0) + 1
-        if kwds:
-            self.update(kwds)
+    >>> c = Counter('which')
+    >>> c.subtract('witch')             # subtract elements from another iterable
+    >>> c.subtract(Counter('watch'))    # subtract elements from another counter
+    >>> c['h']                          # 2 in which, minus 1 in witch, minus 1 in watch
+    0
+    >>> c['w']                          # 1 in which, minus 1 in witch, minus 1 in watch
+    -1
 
-    def subtract(*args, **kwds):
-        '''Like dict.update() but subtracts counts instead of replacing them.
-        Counts can be reduced below zero.  Both the inputs and outputs are
-        allowed to contain zero and negative counts.
+    '''
+    if not args:
+      raise TypeError("descriptor 'subtract' of 'Counter' object "
+                      "needs an argument")
+    self = args[0]
+    args = args[1:]
+    if len(args) > 1:
+      raise TypeError('expected at most 1 arguments, got %d' % len(args))
+    iterable = args[0] if args else None
+    if iterable is not None:
+      self_get = self.get
+      if isinstance(iterable, Mapping):
+        for elem, count in iterable.items():
+          self[elem] = self_get(elem, 0) - count
+      else:
+        for elem in iterable:
+          self[elem] = self_get(elem, 0) - 1
+    if kwds:
+      self.subtract(kwds)
 
-        Source can be an iterable, a dictionary, or another Counter instance.
+  def copy(self):
+    'Return a shallow copy.'
+    return self.__class__(self)
 
-        >>> c = Counter('which')
-        >>> c.subtract('witch')             # subtract elements from another iterable
-        >>> c.subtract(Counter('watch'))    # subtract elements from another counter
-        >>> c['h']                          # 2 in which, minus 1 in witch, minus 1 in watch
-        0
-        >>> c['w']                          # 1 in which, minus 1 in witch, minus 1 in watch
-        -1
+  def __reduce__(self):
+    return self.__class__, (dict(self),)
 
-        '''
-        if not args:
-            raise TypeError("descriptor 'subtract' of 'Counter' object "
-                            "needs an argument")
-        self = args[0]
-        args = args[1:]
-        if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        iterable = args[0] if args else None
-        if iterable is not None:
-            self_get = self.get
-            if isinstance(iterable, Mapping):
-                for elem, count in iterable.items():
-                    self[elem] = self_get(elem, 0) - count
-            else:
-                for elem in iterable:
-                    self[elem] = self_get(elem, 0) - 1
-        if kwds:
-            self.subtract(kwds)
+  def __delitem__(self, elem):
+    'Like dict.__delitem__() but does not raise KeyError for missing values.'
+    if elem in self:
+      super(Counter, self).__delitem__(elem)
 
-    def copy(self):
-        'Return a shallow copy.'
-        return self.__class__(self)
+  def __repr__(self):
+    if not self:
+      return '%s()' % self.__class__.__name__
+    items = ', '.join(map('%r: %r'.__mod__, self.most_common()))
+    return '%s({%s})' % (self.__class__.__name__, items)
 
-    def __reduce__(self):
-        return self.__class__, (dict(self),)
+  # Multiset-style mathematical operations discussed in:
+  #       Knuth TAOCP Volume II section 4.6.3 exercise 19
+  #       and at http://en.wikipedia.org/wiki/Multiset
+  #
+  # Outputs guaranteed to only include positive counts.
+  #
+  # To strip negative and zero counts, add-in an empty counter:
+  #       c += Counter()
 
-    def __delitem__(self, elem):
-        'Like dict.__delitem__() but does not raise KeyError for missing values.'
-        if elem in self:
-            super(Counter, self).__delitem__(elem)
+  def __add__(self, other):
+    '''Add counts from two counters.
 
-    def __repr__(self):
-        if not self:
-            return '%s()' % self.__class__.__name__
-        items = ', '.join(map('%r: %r'.__mod__, self.most_common()))
-        return '%s({%s})' % (self.__class__.__name__, items)
+    >>> Counter('abbb') + Counter('bcc')
+    Counter({'b': 4, 'c': 2, 'a': 1})
 
-    # Multiset-style mathematical operations discussed in:
-    #       Knuth TAOCP Volume II section 4.6.3 exercise 19
-    #       and at http://en.wikipedia.org/wiki/Multiset
-    #
-    # Outputs guaranteed to only include positive counts.
-    #
-    # To strip negative and zero counts, add-in an empty counter:
-    #       c += Counter()
+    '''
+    if not isinstance(other, Counter):
+      return NotImplemented
+    result = Counter()
+    for elem, count in self.items():
+      newcount = count + other[elem]
+      if newcount > 0:
+        result[elem] = newcount
+    for elem, count in other.items():
+      if elem not in self and count > 0:
+        result[elem] = count
+    return result
 
-    def __add__(self, other):
-        '''Add counts from two counters.
+  def __sub__(self, other):
+    ''' Subtract count, but keep only results with positive counts.
 
-        >>> Counter('abbb') + Counter('bcc')
-        Counter({'b': 4, 'c': 2, 'a': 1})
+    >>> Counter('abbbc') - Counter('bccd')
+    Counter({'b': 2, 'a': 1})
 
-        '''
-        if not isinstance(other, Counter):
-            return NotImplemented
-        result = Counter()
-        for elem, count in self.items():
-            newcount = count + other[elem]
-            if newcount > 0:
-                result[elem] = newcount
-        for elem, count in other.items():
-            if elem not in self and count > 0:
-                result[elem] = count
-        return result
+    '''
+    if not isinstance(other, Counter):
+      return NotImplemented
+    result = Counter()
+    for elem, count in self.items():
+      newcount = count - other[elem]
+      if newcount > 0:
+        result[elem] = newcount
+    for elem, count in other.items():
+      if elem not in self and count < 0:
+        result[elem] = 0 - count
+    return result
 
-    def __sub__(self, other):
-        ''' Subtract count, but keep only results with positive counts.
+  def __or__(self, other):
+    '''Union is the maximum of value in either of the input counters.
 
-        >>> Counter('abbbc') - Counter('bccd')
-        Counter({'b': 2, 'a': 1})
+    >>> Counter('abbb') | Counter('bcc')
+    Counter({'b': 3, 'c': 2, 'a': 1})
 
-        '''
-        if not isinstance(other, Counter):
-            return NotImplemented
-        result = Counter()
-        for elem, count in self.items():
-            newcount = count - other[elem]
-            if newcount > 0:
-                result[elem] = newcount
-        for elem, count in other.items():
-            if elem not in self and count < 0:
-                result[elem] = 0 - count
-        return result
+    '''
+    if not isinstance(other, Counter):
+      return NotImplemented
+    result = Counter()
+    for elem, count in self.items():
+      other_count = other[elem]
+      newcount = other_count if count < other_count else count
+      if newcount > 0:
+        result[elem] = newcount
+    for elem, count in other.items():
+      if elem not in self and count > 0:
+        result[elem] = count
+    return result
 
-    def __or__(self, other):
-        '''Union is the maximum of value in either of the input counters.
+  def __and__(self, other):
+    ''' Intersection is the minimum of corresponding counts.
 
-        >>> Counter('abbb') | Counter('bcc')
-        Counter({'b': 3, 'c': 2, 'a': 1})
+    >>> Counter('abbb') & Counter('bcc')
+    Counter({'b': 1})
 
-        '''
-        if not isinstance(other, Counter):
-            return NotImplemented
-        result = Counter()
-        for elem, count in self.items():
-            other_count = other[elem]
-            newcount = other_count if count < other_count else count
-            if newcount > 0:
-                result[elem] = newcount
-        for elem, count in other.items():
-            if elem not in self and count > 0:
-                result[elem] = count
-        return result
-
-    def __and__(self, other):
-        ''' Intersection is the minimum of corresponding counts.
-
-        >>> Counter('abbb') & Counter('bcc')
-        Counter({'b': 1})
-
-        '''
-        if not isinstance(other, Counter):
-            return NotImplemented
-        result = Counter()
-        for elem, count in self.items():
-            other_count = other[elem]
-            newcount = count if count < other_count else other_count
-            if newcount > 0:
-                result[elem] = newcount
-        return result
+    '''
+    if not isinstance(other, Counter):
+      return NotImplemented
+    result = Counter()
+    for elem, count in self.items():
+      other_count = other[elem]
+      newcount = count if count < other_count else other_count
+      if newcount > 0:
+        result[elem] = newcount
+    return result
 
 
 if __name__ == '__main__':
-    pass
+  pass
 #    # verify that instances can be pickled
 #    from cPickle import loads, dumps
 #    Point = namedtuple('Point', 'x, y', True)

--- a/third_party/stdlib/collections.py
+++ b/third_party/stdlib/collections.py
@@ -10,7 +10,7 @@ list, set, and tuple.
 
 '''
 
-__all__ = ['Counter', 'OrderedDict', 'deque']  # 'namedtuple', 'defaultdict',
+__all__ = ['Counter', 'namedtuple', 'OrderedDict', 'deque'] # 'deque', 'defaultdict',
 # For bootstrapping reasons, the collection ABCs are defined in _abcoll.py.
 # They should however be considered an integral part of collections.py.
 import _abcoll
@@ -20,7 +20,7 @@ for name in _abcoll.__all__:
 
 import _collections
 deque = _collections.deque
-# defaultdict = _collections.defaultdict
+#defaultdict = _collections.defaultdict
 import operator
 _itemgetter = operator.itemgetter
 _eq = operator.eq
@@ -34,228 +34,228 @@ _chain = itertools.chain
 _starmap = itertools.starmap
 _imap = itertools.imap
 
-# try:
+#try:
 import thread
 _get_ident = thread.get_ident
-# except ImportError:
+#except ImportError:
 #    from dummy_thread import get_ident as _get_ident
 
 
 ################################################################################
-# OrderedDict
+### OrderedDict
 ################################################################################
 
 class OrderedDict(dict):
-  'Dictionary that remembers insertion order'
-  # An inherited dict maps keys to values.
-  # The inherited dict provides __getitem__, __len__, __contains__, and get.
-  # The remaining methods are order-aware.
-  # Big-O running times for all methods are the same as regular dictionaries.
+    'Dictionary that remembers insertion order'
+    # An inherited dict maps keys to values.
+    # The inherited dict provides __getitem__, __len__, __contains__, and get.
+    # The remaining methods are order-aware.
+    # Big-O running times for all methods are the same as regular dictionaries.
 
-  # The internal self.__map dict maps keys to links in a doubly linked list.
-  # The circular doubly linked list starts and ends with a sentinel element.
-  # The sentinel element never gets deleted (this simplifies the algorithm).
-  # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+    # The internal self.__map dict maps keys to links in a doubly linked list.
+    # The circular doubly linked list starts and ends with a sentinel element.
+    # The sentinel element never gets deleted (this simplifies the algorithm).
+    # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
 
-  def __init__(*args, **kwds):
-    '''Initialize an ordered dictionary.  The signature is the same as
-    regular dictionaries, but keyword arguments are not recommended because
-    their insertion order is arbitrary.
+    def __init__(*args, **kwds):
+        '''Initialize an ordered dictionary.  The signature is the same as
+        regular dictionaries, but keyword arguments are not recommended because
+        their insertion order is arbitrary.
 
-    '''
-    if not args:
-      raise TypeError("descriptor '__init__' of 'OrderedDict' object "
-                      "needs an argument")
-    self = args[0]
-    args = args[1:]
-    if len(args) > 1:
-      raise TypeError('expected at most 1 arguments, got %d' % len(args))
-    try:
-      self.__root
-    except AttributeError:
-      self.__root = root = []                     # sentinel node
-      root[:] = [root, root, None]
-      self.__map = {}
-    self.__update(*args, **kwds)
+        '''
+        if not args:
+            raise TypeError("descriptor '__init__' of 'OrderedDict' object "
+                            "needs an argument")
+        self = args[0]
+        args = args[1:]
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__root
+        except AttributeError:
+            self.__root = root = []                     # sentinel node
+            root[:] = [root, root, None]
+            self.__map = {}
+        self.__update(*args, **kwds)
 
-  def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
-    'od.__setitem__(i, y) <==> od[i]=y'
-    # Setting a new item creates a new link at the end of the linked list,
-    # and the inherited dictionary is updated with the new key/value pair.
-    if key not in self:
-      root = self.__root
-      last = root[0]
-      last[1] = root[0] = self.__map[key] = [last, root, key]
-    return dict_setitem(self, key, value)
+    def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+        'od.__setitem__(i, y) <==> od[i]=y'
+        # Setting a new item creates a new link at the end of the linked list,
+        # and the inherited dictionary is updated with the new key/value pair.
+        if key not in self:
+            root = self.__root
+            last = root[0]
+            last[1] = root[0] = self.__map[key] = [last, root, key]
+        return dict_setitem(self, key, value)
 
-  def __delitem__(self, key, dict_delitem=dict.__delitem__):
-    'od.__delitem__(y) <==> del od[y]'
-    # Deleting an existing item uses self.__map to find the link which gets
-    # removed by updating the links in the predecessor and successor nodes.
-    dict_delitem(self, key)
-    link_prev, link_next, _ = self.__map.pop(key)
-    link_prev[1] = link_next                        # update link_prev[NEXT]
-    link_next[0] = link_prev                        # update link_next[PREV]
+    def __delitem__(self, key, dict_delitem=dict.__delitem__):
+        'od.__delitem__(y) <==> del od[y]'
+        # Deleting an existing item uses self.__map to find the link which gets
+        # removed by updating the links in the predecessor and successor nodes.
+        dict_delitem(self, key)
+        link_prev, link_next, _ = self.__map.pop(key)
+        link_prev[1] = link_next                        # update link_prev[NEXT]
+        link_next[0] = link_prev                        # update link_next[PREV]
 
-  def __iter__(self):
-    'od.__iter__() <==> iter(od)'
-    # Traverse the linked list in order.
-    root = self.__root
-    curr = root[1]                                  # start at the first node
-    while curr is not root:
-      yield curr[2]                               # yield the curr[KEY]
-      curr = curr[1]                              # move to next node
+    def __iter__(self):
+        'od.__iter__() <==> iter(od)'
+        # Traverse the linked list in order.
+        root = self.__root
+        curr = root[1]                                  # start at the first node
+        while curr is not root:
+            yield curr[2]                               # yield the curr[KEY]
+            curr = curr[1]                              # move to next node
 
-  def __reversed__(self):
-    'od.__reversed__() <==> reversed(od)'
-    # Traverse the linked list in reverse order.
-    root = self.__root
-    curr = root[0]                                  # start at the last node
-    while curr is not root:
-      yield curr[2]                               # yield the curr[KEY]
-      curr = curr[0]                              # move to previous node
+    def __reversed__(self):
+        'od.__reversed__() <==> reversed(od)'
+        # Traverse the linked list in reverse order.
+        root = self.__root
+        curr = root[0]                                  # start at the last node
+        while curr is not root:
+            yield curr[2]                               # yield the curr[KEY]
+            curr = curr[0]                              # move to previous node
 
-  def clear(self):
-    'od.clear() -> None.  Remove all items from od.'
-    root = self.__root
-    root[:] = [root, root, None]
-    self.__map.clear()
-    dict.clear(self)
+    def clear(self):
+        'od.clear() -> None.  Remove all items from od.'
+        root = self.__root
+        root[:] = [root, root, None]
+        self.__map.clear()
+        dict.clear(self)
 
-  # -- the following methods do not depend on the internal structure --
+    # -- the following methods do not depend on the internal structure --
 
-  def keys(self):
-    'od.keys() -> list of keys in od'
-    return list(self)
+    def keys(self):
+        'od.keys() -> list of keys in od'
+        return list(self)
 
-  def values(self):
-    'od.values() -> list of values in od'
-    return [self[key] for key in self]
+    def values(self):
+        'od.values() -> list of values in od'
+        return [self[key] for key in self]
 
-  def items(self):
-    'od.items() -> list of (key, value) pairs in od'
-    return [(key, self[key]) for key in self]
+    def items(self):
+        'od.items() -> list of (key, value) pairs in od'
+        return [(key, self[key]) for key in self]
 
-  def iterkeys(self):
-    'od.iterkeys() -> an iterator over the keys in od'
-    return iter(self)
+    def iterkeys(self):
+        'od.iterkeys() -> an iterator over the keys in od'
+        return iter(self)
 
-  def itervalues(self):
-    'od.itervalues -> an iterator over the values in od'
-    for k in self:
-      yield self[k]
+    def itervalues(self):
+        'od.itervalues -> an iterator over the values in od'
+        for k in self:
+            yield self[k]
 
-  def iteritems(self):
-    'od.iteritems -> an iterator over the (key, value) pairs in od'
-    for k in self:
-      yield (k, self[k])
+    def iteritems(self):
+        'od.iteritems -> an iterator over the (key, value) pairs in od'
+        for k in self:
+            yield (k, self[k])
 
-  update = MutableMapping.update
+    update = MutableMapping.update
 
-  __update = update  # let subclasses override update without breaking __init__
+    __update = update # let subclasses override update without breaking __init__
 
-  __marker = object()
+    __marker = object()
 
-  def pop(self, key, default=__marker):
-    '''od.pop(k[,d]) -> v, remove specified key and return the corresponding
-    value.  If key is not found, d is returned if given, otherwise KeyError
-    is raised.
+    def pop(self, key, default=__marker):
+        '''od.pop(k[,d]) -> v, remove specified key and return the corresponding
+        value.  If key is not found, d is returned if given, otherwise KeyError
+        is raised.
 
-    '''
-    if key in self:
-      result = self[key]
-      del self[key]
-      return result
-    if default is self.__marker:
-      raise KeyError(key)
-    return default
+        '''
+        if key in self:
+            result = self[key]
+            del self[key]
+            return result
+        if default is self.__marker:
+            raise KeyError(key)
+        return default
 
-  def setdefault(self, key, default=None):
-    'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
-    if key in self:
-      return self[key]
-    self[key] = default
-    return default
+    def setdefault(self, key, default=None):
+        'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+        if key in self:
+            return self[key]
+        self[key] = default
+        return default
 
-  def popitem(self, last=True):
-    '''od.popitem() -> (k, v), return and remove a (key, value) pair.
-    Pairs are returned in LIFO order if last is true or FIFO order if false.
+    def popitem(self, last=True):
+        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
 
-    '''
-    if not self:
-      raise KeyError('dictionary is empty')
-    key = next(reversed(self) if last else iter(self))
-    value = self.pop(key)
-    return key, value
+        '''
+        if not self:
+            raise KeyError('dictionary is empty')
+        key = next(reversed(self) if last else iter(self))
+        value = self.pop(key)
+        return key, value
 
-  def __repr__(self, _repr_running={}):
-    'od.__repr__() <==> repr(od)'
-    call_key = id(self), _get_ident()
-    if call_key in _repr_running:
-      return '...'
-    _repr_running[call_key] = 1
-    try:
-      if not self:
-        return '%s()' % (self.__class__.__name__,)
-      return '%s(%r)' % (self.__class__.__name__, self.items())
-    finally:
-      del _repr_running[call_key]
+    def __repr__(self, _repr_running={}):
+        'od.__repr__() <==> repr(od)'
+        call_key = id(self), _get_ident()
+        if call_key in _repr_running:
+            return '...'
+        _repr_running[call_key] = 1
+        try:
+            if not self:
+                return '%s()' % (self.__class__.__name__,)
+            return '%s(%r)' % (self.__class__.__name__, self.items())
+        finally:
+            del _repr_running[call_key]
 
-  def __reduce__(self):
-    'Return state information for pickling'
-    items = [[k, self[k]] for k in self]
-    inst_dict = vars(self).copy()
-    for k in vars(OrderedDict()):
-      inst_dict.pop(k, None)
-    if inst_dict:
-      return (self.__class__, (items,), inst_dict)
-    return self.__class__, (items,)
+    def __reduce__(self):
+        'Return state information for pickling'
+        items = [[k, self[k]] for k in self]
+        inst_dict = vars(self).copy()
+        for k in vars(OrderedDict()):
+            inst_dict.pop(k, None)
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
 
-  def copy(self):
-    'od.copy() -> a shallow copy of od'
-    return self.__class__(self)
+    def copy(self):
+        'od.copy() -> a shallow copy of od'
+        return self.__class__(self)
 
-  @classmethod
-  def fromkeys(cls, iterable, value=None):
-    '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.
-    If not specified, the value defaults to None.
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S.
+        If not specified, the value defaults to None.
 
-    '''
-    self = cls()
-    for key in iterable:
-      self[key] = value
-    return self
+        '''
+        self = cls()
+        for key in iterable:
+            self[key] = value
+        return self
 
-  def __eq__(self, other):
-    '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
-    while comparison to a regular mapping is order-insensitive.
+    def __eq__(self, other):
+        '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+        while comparison to a regular mapping is order-insensitive.
 
-    '''
-    if isinstance(other, OrderedDict):
-      return dict.__eq__(self, other) and all(_imap(_eq, self, other))
-    return dict.__eq__(self, other)
+        '''
+        if isinstance(other, OrderedDict):
+            return dict.__eq__(self, other) and all(_imap(_eq, self, other))
+        return dict.__eq__(self, other)
 
-  def __ne__(self, other):
-    'od.__ne__(y) <==> od!=y'
-    return not self == other
+    def __ne__(self, other):
+        'od.__ne__(y) <==> od!=y'
+        return not self == other
 
-  # -- the following methods support python 3.x style dictionary views --
+    # -- the following methods support python 3.x style dictionary views --
 
-  def viewkeys(self):
-    "od.viewkeys() -> a set-like object providing a view on od's keys"
-    return KeysView(self)
+    def viewkeys(self):
+        "od.viewkeys() -> a set-like object providing a view on od's keys"
+        return KeysView(self)
 
-  def viewvalues(self):
-    "od.viewvalues() -> an object providing a view on od's values"
-    return ValuesView(self)
+    def viewvalues(self):
+        "od.viewvalues() -> an object providing a view on od's values"
+        return ValuesView(self)
 
-  def viewitems(self):
-    "od.viewitems() -> a set-like object providing a view on od's items"
-    return ItemsView(self)
+    def viewitems(self):
+        "od.viewitems() -> a set-like object providing a view on od's items"
+        return ItemsView(self)
 
 
 ################################################################################
-# namedtuple
+### namedtuple
 ################################################################################
 
 _class_template = '''\
@@ -312,7 +312,7 @@ _field_template = '''\
     {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
 '''
 
-# def namedtuple(typename, field_names, verbose=False, rename=False):
+#def namedtuple(typename, field_names, verbose=False, rename=False):
 #    """Returns a new subclass of tuple with named fields.
 #
 #    >>> Point = namedtuple('Point', ['x', 'y'])
@@ -411,314 +411,313 @@ _field_template = '''\
 
 
 ########################################################################
-# Counter
+###  Counter
 ########################################################################
 
 class Counter(dict):
-  '''Dict subclass for counting hashable items.  Sometimes called a bag
-  or multiset.  Elements are stored as dictionary keys and their counts
-  are stored as dictionary values.
+    '''Dict subclass for counting hashable items.  Sometimes called a bag
+    or multiset.  Elements are stored as dictionary keys and their counts
+    are stored as dictionary values.
 
-  >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
+    >>> c = Counter('abcdeabcdabcaba')  # count elements from a string
 
-  >>> c.most_common(3)                # three most common elements
-  [('a', 5), ('b', 4), ('c', 3)]
-  >>> sorted(c)                       # list all unique elements
-  ['a', 'b', 'c', 'd', 'e']
-  >>> ''.join(sorted(c.elements()))   # list elements with repetitions
-  'aaaaabbbbcccdde'
-  >>> sum(c.values())                 # total of all counts
-  15
-
-  >>> c['a']                          # count of letter 'a'
-  5
-  >>> for elem in 'shazam':           # update counts from an iterable
-  ...     c[elem] += 1                # by adding 1 to each element's count
-  >>> c['a']                          # now there are seven 'a'
-  7
-  >>> del c['b']                      # remove all 'b'
-  >>> c['b']                          # now there are zero 'b'
-  0
-
-  >>> d = Counter('simsalabim')       # make another counter
-  >>> c.update(d)                     # add in the second counter
-  >>> c['a']                          # now there are nine 'a'
-  9
-
-  >>> c.clear()                       # empty the counter
-  >>> c
-  Counter()
-
-  Note:  If a count is set to zero or reduced to zero, it will remain
-  in the counter until the entry is deleted or the counter is cleared:
-
-  >>> c = Counter('aaabbc')
-  >>> c['b'] -= 2                     # reduce the count of 'b' by two
-  >>> c.most_common()                 # 'b' is still in, but its count is zero
-  [('a', 3), ('c', 1), ('b', 0)]
-
-  '''
-  # References:
-  #   http://en.wikipedia.org/wiki/Multiset
-  #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
-  #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
-  #   http://code.activestate.com/recipes/259174/
-  #   Knuth, TAOCP Vol. II section 4.6.3
-
-  def __init__(*args, **kwds):
-    '''Create a new, empty Counter object.  And if given, count elements
-    from an input iterable.  Or, initialize the count from another mapping
-    of elements to their counts.
-
-    >>> c = Counter()                           # a new, empty counter
-    >>> c = Counter('gallahad')                 # a new counter from an iterable
-    >>> c = Counter({'a': 4, 'b': 2})           # a new counter from a mapping
-    >>> c = Counter(a=4, b=2)                   # a new counter from keyword args
-
-    '''
-    if not args:
-      raise TypeError("descriptor '__init__' of 'Counter' object "
-                      "needs an argument")
-    self = args[0]
-    args = args[1:]
-    if len(args) > 1:
-      raise TypeError('expected at most 1 arguments, got %d' % len(args))
-    super(Counter, self).__init__()
-    self.update(*args, **kwds)
-
-  def __missing__(self, key):
-    'The count of elements not in the Counter is zero.'
-    # Needed so that self[missing_item] does not raise KeyError
-    return 0
-
-  def most_common(self, n=None):
-    '''List the n most common elements and their counts from the most
-    common to the least.  If n is None, then list all element counts.
-
-    >>> Counter('abcdeabcdabcaba').most_common(3)
+    >>> c.most_common(3)                # three most common elements
     [('a', 5), ('b', 4), ('c', 3)]
+    >>> sorted(c)                       # list all unique elements
+    ['a', 'b', 'c', 'd', 'e']
+    >>> ''.join(sorted(c.elements()))   # list elements with repetitions
+    'aaaaabbbbcccdde'
+    >>> sum(c.values())                 # total of all counts
+    15
 
-    '''
-    # Emulate Bag.sortedByCount from Smalltalk
-    if n is None:
-      return sorted(self.iteritems(), key=_itemgetter(1), reverse=True)
-    return _heapq.nlargest(n, self.iteritems(), key=_itemgetter(1))
-
-  def elements(self):
-    '''Iterator over elements repeating each as many times as its count.
-
-    >>> c = Counter('ABCABC')
-    >>> sorted(c.elements())
-    ['A', 'A', 'B', 'B', 'C', 'C']
-
-    # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
-    >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
-    >>> product = 1
-    >>> for factor in prime_factors.elements():     # loop over factors
-    ...     product *= factor                       # and multiply them
-    >>> product
-    1836
-
-    Note, if an element's count has been set to zero or is a negative
-    number, elements() will ignore it.
-
-    '''
-    # Emulate Bag.do from Smalltalk and Multiset.begin from C++.
-    return _chain.from_iterable(_starmap(_repeat, self.iteritems()))
-
-  # Override dict methods where necessary
-
-  @classmethod
-  def fromkeys(cls, iterable, v=None):
-    # There is no equivalent method for counters because setting v=1
-    # means that no element can have a count greater than one.
-    raise NotImplementedError(
-        'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.')
-
-  def update(*args, **kwds):
-    '''Like dict.update() but add counts instead of replacing them.
-
-    Source can be an iterable, a dictionary, or another Counter instance.
-
-    >>> c = Counter('which')
-    >>> c.update('witch')           # add elements from another iterable
-    >>> d = Counter('watch')
-    >>> c.update(d)                 # add elements from another counter
-    >>> c['h']                      # four 'h' in which, witch, and watch
-    4
-
-    '''
-    # The regular dict.update() operation makes no sense here because the
-    # replace behavior results in the some of original untouched counts
-    # being mixed-in with all of the other counts for a mismash that
-    # doesn't have a straight-forward interpretation in most counting
-    # contexts.  Instead, we implement straight-addition.  Both the inputs
-    # and outputs are allowed to contain zero and negative counts.
-
-    if not args:
-      raise TypeError("descriptor 'update' of 'Counter' object "
-                      "needs an argument")
-    self = args[0]
-    args = args[1:]
-    if len(args) > 1:
-      raise TypeError('expected at most 1 arguments, got %d' % len(args))
-    iterable = args[0] if args else None
-    if iterable is not None:
-      if isinstance(iterable, Mapping):
-        if self:
-          self_get = self.get
-          for elem, count in iterable.iteritems():
-            self[elem] = self_get(elem, 0) + count
-        else:
-          # fast path when counter is empty
-          super(Counter, self).update(iterable)
-      else:
-        self_get = self.get
-        for elem in iterable:
-          self[elem] = self_get(elem, 0) + 1
-    if kwds:
-      self.update(kwds)
-
-  def subtract(*args, **kwds):
-    '''Like dict.update() but subtracts counts instead of replacing them.
-    Counts can be reduced below zero.  Both the inputs and outputs are
-    allowed to contain zero and negative counts.
-
-    Source can be an iterable, a dictionary, or another Counter instance.
-
-    >>> c = Counter('which')
-    >>> c.subtract('witch')             # subtract elements from another iterable
-    >>> c.subtract(Counter('watch'))    # subtract elements from another counter
-    >>> c['h']                          # 2 in which, minus 1 in witch, minus 1 in watch
+    >>> c['a']                          # count of letter 'a'
+    5
+    >>> for elem in 'shazam':           # update counts from an iterable
+    ...     c[elem] += 1                # by adding 1 to each element's count
+    >>> c['a']                          # now there are seven 'a'
+    7
+    >>> del c['b']                      # remove all 'b'
+    >>> c['b']                          # now there are zero 'b'
     0
-    >>> c['w']                          # 1 in which, minus 1 in witch, minus 1 in watch
-    -1
+
+    >>> d = Counter('simsalabim')       # make another counter
+    >>> c.update(d)                     # add in the second counter
+    >>> c['a']                          # now there are nine 'a'
+    9
+
+    >>> c.clear()                       # empty the counter
+    >>> c
+    Counter()
+
+    Note:  If a count is set to zero or reduced to zero, it will remain
+    in the counter until the entry is deleted or the counter is cleared:
+
+    >>> c = Counter('aaabbc')
+    >>> c['b'] -= 2                     # reduce the count of 'b' by two
+    >>> c.most_common()                 # 'b' is still in, but its count is zero
+    [('a', 3), ('c', 1), ('b', 0)]
 
     '''
-    if not args:
-      raise TypeError("descriptor 'subtract' of 'Counter' object "
-                      "needs an argument")
-    self = args[0]
-    args = args[1:]
-    if len(args) > 1:
-      raise TypeError('expected at most 1 arguments, got %d' % len(args))
-    iterable = args[0] if args else None
-    if iterable is not None:
-      self_get = self.get
-      if isinstance(iterable, Mapping):
-        for elem, count in iterable.items():
-          self[elem] = self_get(elem, 0) - count
-      else:
-        for elem in iterable:
-          self[elem] = self_get(elem, 0) - 1
-    if kwds:
-      self.subtract(kwds)
+    # References:
+    #   http://en.wikipedia.org/wiki/Multiset
+    #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
+    #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
+    #   http://code.activestate.com/recipes/259174/
+    #   Knuth, TAOCP Vol. II section 4.6.3
 
-  def copy(self):
-    'Return a shallow copy.'
-    return self.__class__(self)
+    def __init__(*args, **kwds):
+        '''Create a new, empty Counter object.  And if given, count elements
+        from an input iterable.  Or, initialize the count from another mapping
+        of elements to their counts.
 
-  def __reduce__(self):
-    return self.__class__, (dict(self),)
+        >>> c = Counter()                           # a new, empty counter
+        >>> c = Counter('gallahad')                 # a new counter from an iterable
+        >>> c = Counter({'a': 4, 'b': 2})           # a new counter from a mapping
+        >>> c = Counter(a=4, b=2)                   # a new counter from keyword args
 
-  def __delitem__(self, elem):
-    'Like dict.__delitem__() but does not raise KeyError for missing values.'
-    if elem in self:
-      super(Counter, self).__delitem__(elem)
+        '''
+        if not args:
+            raise TypeError("descriptor '__init__' of 'Counter' object "
+                            "needs an argument")
+        self = args[0]
+        args = args[1:]
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        super(Counter, self).__init__()
+        self.update(*args, **kwds)
 
-  def __repr__(self):
-    if not self:
-      return '%s()' % self.__class__.__name__
-    items = ', '.join(map('%r: %r'.__mod__, self.most_common()))
-    return '%s({%s})' % (self.__class__.__name__, items)
+    def __missing__(self, key):
+        'The count of elements not in the Counter is zero.'
+        # Needed so that self[missing_item] does not raise KeyError
+        return 0
 
-  # Multiset-style mathematical operations discussed in:
-  #       Knuth TAOCP Volume II section 4.6.3 exercise 19
-  #       and at http://en.wikipedia.org/wiki/Multiset
-  #
-  # Outputs guaranteed to only include positive counts.
-  #
-  # To strip negative and zero counts, add-in an empty counter:
-  #       c += Counter()
+    def most_common(self, n=None):
+        '''List the n most common elements and their counts from the most
+        common to the least.  If n is None, then list all element counts.
 
-  def __add__(self, other):
-    '''Add counts from two counters.
+        >>> Counter('abcdeabcdabcaba').most_common(3)
+        [('a', 5), ('b', 4), ('c', 3)]
 
-    >>> Counter('abbb') + Counter('bcc')
-    Counter({'b': 4, 'c': 2, 'a': 1})
+        '''
+        # Emulate Bag.sortedByCount from Smalltalk
+        if n is None:
+            return sorted(self.iteritems(), key=_itemgetter(1), reverse=True)
+        return _heapq.nlargest(n, self.iteritems(), key=_itemgetter(1))
 
-    '''
-    if not isinstance(other, Counter):
-      return NotImplemented
-    result = Counter()
-    for elem, count in self.items():
-      newcount = count + other[elem]
-      if newcount > 0:
-        result[elem] = newcount
-    for elem, count in other.items():
-      if elem not in self and count > 0:
-        result[elem] = count
-    return result
+    def elements(self):
+        '''Iterator over elements repeating each as many times as its count.
 
-  def __sub__(self, other):
-    ''' Subtract count, but keep only results with positive counts.
+        >>> c = Counter('ABCABC')
+        >>> sorted(c.elements())
+        ['A', 'A', 'B', 'B', 'C', 'C']
 
-    >>> Counter('abbbc') - Counter('bccd')
-    Counter({'b': 2, 'a': 1})
+        # Knuth's example for prime factors of 1836:  2**2 * 3**3 * 17**1
+        >>> prime_factors = Counter({2: 2, 3: 3, 17: 1})
+        >>> product = 1
+        >>> for factor in prime_factors.elements():     # loop over factors
+        ...     product *= factor                       # and multiply them
+        >>> product
+        1836
 
-    '''
-    if not isinstance(other, Counter):
-      return NotImplemented
-    result = Counter()
-    for elem, count in self.items():
-      newcount = count - other[elem]
-      if newcount > 0:
-        result[elem] = newcount
-    for elem, count in other.items():
-      if elem not in self and count < 0:
-        result[elem] = 0 - count
-    return result
+        Note, if an element's count has been set to zero or is a negative
+        number, elements() will ignore it.
 
-  def __or__(self, other):
-    '''Union is the maximum of value in either of the input counters.
+        '''
+        # Emulate Bag.do from Smalltalk and Multiset.begin from C++.
+        return _chain.from_iterable(_starmap(_repeat, self.iteritems()))
 
-    >>> Counter('abbb') | Counter('bcc')
-    Counter({'b': 3, 'c': 2, 'a': 1})
+    # Override dict methods where necessary
 
-    '''
-    if not isinstance(other, Counter):
-      return NotImplemented
-    result = Counter()
-    for elem, count in self.items():
-      other_count = other[elem]
-      newcount = other_count if count < other_count else count
-      if newcount > 0:
-        result[elem] = newcount
-    for elem, count in other.items():
-      if elem not in self and count > 0:
-        result[elem] = count
-    return result
+    @classmethod
+    def fromkeys(cls, iterable, v=None):
+        # There is no equivalent method for counters because setting v=1
+        # means that no element can have a count greater than one.
+        raise NotImplementedError(
+            'Counter.fromkeys() is undefined.  Use Counter(iterable) instead.')
 
-  def __and__(self, other):
-    ''' Intersection is the minimum of corresponding counts.
+    def update(*args, **kwds):
+        '''Like dict.update() but add counts instead of replacing them.
 
-    >>> Counter('abbb') & Counter('bcc')
-    Counter({'b': 1})
+        Source can be an iterable, a dictionary, or another Counter instance.
 
-    '''
-    if not isinstance(other, Counter):
-      return NotImplemented
-    result = Counter()
-    for elem, count in self.items():
-      other_count = other[elem]
-      newcount = count if count < other_count else other_count
-      if newcount > 0:
-        result[elem] = newcount
-    return result
+        >>> c = Counter('which')
+        >>> c.update('witch')           # add elements from another iterable
+        >>> d = Counter('watch')
+        >>> c.update(d)                 # add elements from another counter
+        >>> c['h']                      # four 'h' in which, witch, and watch
+        4
+
+        '''
+        # The regular dict.update() operation makes no sense here because the
+        # replace behavior results in the some of original untouched counts
+        # being mixed-in with all of the other counts for a mismash that
+        # doesn't have a straight-forward interpretation in most counting
+        # contexts.  Instead, we implement straight-addition.  Both the inputs
+        # and outputs are allowed to contain zero and negative counts.
+
+        if not args:
+            raise TypeError("descriptor 'update' of 'Counter' object "
+                            "needs an argument")
+        self = args[0]
+        args = args[1:]
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        iterable = args[0] if args else None
+        if iterable is not None:
+            if isinstance(iterable, Mapping):
+                if self:
+                    self_get = self.get
+                    for elem, count in iterable.iteritems():
+                        self[elem] = self_get(elem, 0) + count
+                else:
+                    super(Counter, self).update(iterable) # fast path when counter is empty
+            else:
+                self_get = self.get
+                for elem in iterable:
+                    self[elem] = self_get(elem, 0) + 1
+        if kwds:
+            self.update(kwds)
+
+    def subtract(*args, **kwds):
+        '''Like dict.update() but subtracts counts instead of replacing them.
+        Counts can be reduced below zero.  Both the inputs and outputs are
+        allowed to contain zero and negative counts.
+
+        Source can be an iterable, a dictionary, or another Counter instance.
+
+        >>> c = Counter('which')
+        >>> c.subtract('witch')             # subtract elements from another iterable
+        >>> c.subtract(Counter('watch'))    # subtract elements from another counter
+        >>> c['h']                          # 2 in which, minus 1 in witch, minus 1 in watch
+        0
+        >>> c['w']                          # 1 in which, minus 1 in witch, minus 1 in watch
+        -1
+
+        '''
+        if not args:
+            raise TypeError("descriptor 'subtract' of 'Counter' object "
+                            "needs an argument")
+        self = args[0]
+        args = args[1:]
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        iterable = args[0] if args else None
+        if iterable is not None:
+            self_get = self.get
+            if isinstance(iterable, Mapping):
+                for elem, count in iterable.items():
+                    self[elem] = self_get(elem, 0) - count
+            else:
+                for elem in iterable:
+                    self[elem] = self_get(elem, 0) - 1
+        if kwds:
+            self.subtract(kwds)
+
+    def copy(self):
+        'Return a shallow copy.'
+        return self.__class__(self)
+
+    def __reduce__(self):
+        return self.__class__, (dict(self),)
+
+    def __delitem__(self, elem):
+        'Like dict.__delitem__() but does not raise KeyError for missing values.'
+        if elem in self:
+            super(Counter, self).__delitem__(elem)
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % self.__class__.__name__
+        items = ', '.join(map('%r: %r'.__mod__, self.most_common()))
+        return '%s({%s})' % (self.__class__.__name__, items)
+
+    # Multiset-style mathematical operations discussed in:
+    #       Knuth TAOCP Volume II section 4.6.3 exercise 19
+    #       and at http://en.wikipedia.org/wiki/Multiset
+    #
+    # Outputs guaranteed to only include positive counts.
+    #
+    # To strip negative and zero counts, add-in an empty counter:
+    #       c += Counter()
+
+    def __add__(self, other):
+        '''Add counts from two counters.
+
+        >>> Counter('abbb') + Counter('bcc')
+        Counter({'b': 4, 'c': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            newcount = count + other[elem]
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count > 0:
+                result[elem] = count
+        return result
+
+    def __sub__(self, other):
+        ''' Subtract count, but keep only results with positive counts.
+
+        >>> Counter('abbbc') - Counter('bccd')
+        Counter({'b': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            newcount = count - other[elem]
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count < 0:
+                result[elem] = 0 - count
+        return result
+
+    def __or__(self, other):
+        '''Union is the maximum of value in either of the input counters.
+
+        >>> Counter('abbb') | Counter('bcc')
+        Counter({'b': 3, 'c': 2, 'a': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            other_count = other[elem]
+            newcount = other_count if count < other_count else count
+            if newcount > 0:
+                result[elem] = newcount
+        for elem, count in other.items():
+            if elem not in self and count > 0:
+                result[elem] = count
+        return result
+
+    def __and__(self, other):
+        ''' Intersection is the minimum of corresponding counts.
+
+        >>> Counter('abbb') & Counter('bcc')
+        Counter({'b': 1})
+
+        '''
+        if not isinstance(other, Counter):
+            return NotImplemented
+        result = Counter()
+        for elem, count in self.items():
+            other_count = other[elem]
+            newcount = count if count < other_count else other_count
+            if newcount > 0:
+                result[elem] = newcount
+        return result
 
 
 if __name__ == '__main__':
-  pass
+    pass
 #    # verify that instances can be pickled
 #    from cPickle import loads, dumps
 #    Point = namedtuple('Point', 'x, y', True)


### PR DESCRIPTION
Added _collections to third_party/pypy, which includes deque and defaultdict. 
deque should works but defaultdict need `__missing__` slot.

```
cat <<EOF > hello.py | make run
import collections

d = collections.deque('ghi')
print d
for elem in d:
  print elem.upper()
d.append('j')
d.appendleft('f')

print d.pop()
print d.popleft()
print list(d)
EOF
```
```
deque(['g', 'h', 'i'])
G
H
I
j
f
['g', 'h', 'i']
```