### PR TITLE
Raise error on wildcard import

### DIFF
--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -364,7 +364,7 @@ class StatementVisitor(ast.NodeVisitor):
         self.block.bind_var(self.writer, asname, mod.expr)
 
   def visit_ImportFrom(self, node):
-    # Check for wildcard member import and raise error.
+    # Wildcard imports are not yet supported.
     for alias in node.names:
       if alias.name == '*':
         msg = 'wildcard member import is not implemented: from %s import %s' % (

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -397,6 +397,10 @@ class StatementVisitor(ast.NodeVisitor):
       # two cases at compile time and the Google style guide forbids the latter
       # so we support that use case only.
       for alias in node.names:
+        if alias.name == '*':
+          msg = 'wildcard member import is not implemented: from %s import %s' % (
+              node.module, alias.name)
+          raise util.ParseError(node, msg)
         name = '{}.{}'.format(node.module, alias.name)
         with self._import(name, name.count('.')) as mod:
           asname = alias.asname or alias.name

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -282,14 +282,6 @@ class StatementVisitorTest(unittest.TestCase):
     self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
                             'import __go__.foo')
 
-  def testImportWildcardMemberRaises(self):
-    regexp = r'wildcard member import is not implemented: from collections import *'
-    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
-                            'from collections import *')
-    regexp = r'wildcard member import is not implemented: from __go__.foo import *'
-    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
-                            'from __go__.foo import *')
-
   def testImportNativeType(self):
     self.assertEqual((0, "<type 'Duration'>\n"), _GrumpRun(textwrap.dedent("""\
         from __go__.time import type_Duration as Duration
@@ -339,6 +331,14 @@ class StatementVisitorTest(unittest.TestCase):
       node = mod.body[0]
       self.assertRaisesRegexp(util.ParseError, want_regexp,
                               stmt.import_from_future, node)
+
+  def testImportWildcardMemberRaises(self):
+    regexp = r'wildcard member import is not implemented: from foo import *'
+    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
+                            'from foo import *')
+    regexp = r'wildcard member import is not implemented: from __go__.foo import *'
+    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
+                            'from __go__.foo import *')
 
   def testVisitFuture(self):
     testcases = [

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -282,6 +282,14 @@ class StatementVisitorTest(unittest.TestCase):
     self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
                             'import __go__.foo')
 
+  def testImportWildcardMemberRaises(self):
+    regexp = r'wildcard member import is not implemented: from collections import *'
+    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
+                            'from collections import *')
+    regexp = r'wildcard member import is not implemented: from __go__.foo import *'
+    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
+                            'from __go__.foo import *')
+
   def testImportNativeType(self):
     self.assertEqual((0, "<type 'Duration'>\n"), _GrumpRun(textwrap.dedent("""\
         from __go__.time import type_Duration as Duration


### PR DESCRIPTION
Raise error on `from module import *`

Before
```
package main: 
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:5:31: expected 'STRING', found '*'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:15:2: expected 'STRING', found 'var'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:17:2: expected 'STRING', found 'var'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:19:2: expected 'STRING', found 'var'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:20:2: expected 'STRING', found 'for'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:21:3: expected 'STRING', found 'switch'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:27:3: expected 'STRING', found 'if'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:28:4: expected 'STRING', found 'continue'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:29:3: expected 'STRING', found '}'
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:30:13: expected 'STRING', found '='
/var/folders/9j/12cqyk6x2s5dc22x2mnlpmmw0000gn/T/tmp5BoqG5.go:31:3: expected 'STRING', found 'if'
make: *** [run] Error 1
```

After
```
line 4: wildcard member import is not implemented: from collections import *
make: *** [run] Error 1
```
