### PR TITLE
Implement sorted() builtin

### DIFF
--- a/lib/__builtin__.py
+++ b/lib/__builtin__.py
@@ -21,5 +21,3 @@ from __go__.grumpy import Builtins
 
 for k, v in Builtins.iteritems():
   globals()[k] = v
-
-

--- a/lib/__builtin__.py
+++ b/lib/__builtin__.py
@@ -21,3 +21,15 @@ from __go__.grumpy import Builtins
 
 for k, v in Builtins.iteritems():
   globals()[k] = v
+
+
+# sorted()
+def sorted(iterable, **kwargs):
+    """sorted(iterable, cmp=None, key=None, reverse=False) --> new sorted list"""
+    res = list(iterable)  # make a copy / expand the iterable
+    # sort teh copy in place and return
+    res.sort(**kwargs)
+    return res
+
+globals()["sorted"] = sorted
+

--- a/lib/__builtin__.py
+++ b/lib/__builtin__.py
@@ -23,13 +23,3 @@ for k, v in Builtins.iteritems():
   globals()[k] = v
 
 
-# sorted()
-def sorted(iterable, **kwargs):
-    """sorted(iterable, cmp=None, key=None, reverse=False) --> new sorted list"""
-    res = list(iterable)  # make a copy / expand the iterable
-    # sort teh copy in place and return
-    res.sort(**kwargs)
-    return res
-
-globals()["sorted"] = sorted
-

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -521,6 +521,33 @@ func builtinRange(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) 
 	return ListType.Call(f, []*Object{r}, nil)
 }
 
+func builtinSorted(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+	var raised *BaseException
+
+	raised = checkFunctionArgs(f, "sorted", args, ObjectType)
+	if raised != nil {
+		return nil, raised
+	}
+	seq := args[0]
+
+	result := NewList()
+	// Iterate over the seq and append the objects to result.
+	raised = seqForEach(f, seq, func(elem *Object) *BaseException {
+		result.Append(elem)
+		return nil
+	})
+	if raised != nil {
+		return nil, raised
+	}
+
+	// FIXME: add kwargs ....
+	raised = result.Sort(f)
+	if raised != nil {
+		return nil, raised
+	}
+	return result.ToObject(), nil
+}
+
 func builtinRepr(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "repr", args, ObjectType); raised != nil {
 		return nil, raised
@@ -575,6 +602,7 @@ func init() {
 		"print":          newBuiltinFunction("print", builtinPrint).ToObject(),
 		"range":          newBuiltinFunction("range", builtinRange).ToObject(),
 		"repr":           newBuiltinFunction("repr", builtinRepr).ToObject(),
+		"sorted":         newBuiltinFunction("sorted", builtinSorted).ToObject(),
 		"True":           True.ToObject(),
 		"unichr":         newBuiltinFunction("unichr", builtinUniChr).ToObject(),
 	}

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -530,6 +530,11 @@ func builtinSorted(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException)
 	}
 	seq := args[0]
 
+	// Fail hard when unexpected KWArgs are provided
+	if len(kwargs) > 0 {
+		return nil, f.RaiseType(SystemErrorType, "sorted() does not support kwargs (yet)")
+	}
+
 	result := NewList()
 	// Iterate over the seq and append the objects to result.
 	raised = seqForEach(f, seq, func(elem *Object) *BaseException {
@@ -540,7 +545,7 @@ func builtinSorted(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException)
 		return nil, raised
 	}
 
-	// FIXME: add kwargs ....
+	// FIXME: handle kwargs: cmp, key and reverse
 	raised = result.Sort(f)
 	if raised != nil {
 		return nil, raised

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -230,6 +230,8 @@ func TestBuiltinFuncs(t *testing.T) {
 		{f: "repr", args: wrapArgs("a", "b", "c"), wantExc: mustCreateException(TypeErrorType, "'repr' requires 1 arguments")},
 		{f: "sorted", args: wrapArgs(newTestList(2, 3, 1)), want: newTestList(1, 2, 3).ToObject()},
 		{f: "sorted", args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'int' object is not iterable")},
+		{f: "sorted", args: wrapArgs(1, 2), wantExc: mustCreateException(TypeErrorType, "'sorted' requires 1 arguments")},
+		{f: "sorted", args: wrapArgs(newTestList(2, 3, 1)), kwargs: wrapKWArgs("reverse", True), wantExc: mustCreateException(SystemErrorType, "sorted() does not support kwargs (yet)")},
 		{f: "unichr", args: wrapArgs(0), want: NewUnicode("\x00").ToObject()},
 		{f: "unichr", args: wrapArgs(65), want: NewStr("A").ToObject()},
 		{f: "unichr", args: wrapArgs(0x120000), wantExc: mustCreateException(ValueErrorType, "unichr() arg not in range(0x10ffff)")},

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -228,6 +228,8 @@ func TestBuiltinFuncs(t *testing.T) {
 		{f: "repr", args: wrapArgs(NewUnicode("abc")), want: NewStr("u'abc'").ToObject()},
 		{f: "repr", args: wrapArgs(newTestTuple("foo", "bar")), want: NewStr("('foo', 'bar')").ToObject()},
 		{f: "repr", args: wrapArgs("a", "b", "c"), wantExc: mustCreateException(TypeErrorType, "'repr' requires 1 arguments")},
+		{f: "sorted", args: wrapArgs(newTestList(2, 3, 1)), want: newTestList(1, 2, 3).ToObject()},
+		{f: "sorted", args: wrapArgs(1), wantExc: mustCreateException(TypeErrorType, "'int' object is not iterable")},
 		{f: "unichr", args: wrapArgs(0), want: NewUnicode("\x00").ToObject()},
 		{f: "unichr", args: wrapArgs(65), want: NewStr("A").ToObject()},
 		{f: "unichr", args: wrapArgs(0x120000), wantExc: mustCreateException(ValueErrorType, "unichr() arg not in range(0x10ffff)")},

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -1,4 +1,6 @@
 
 
-assert sorted([1,3,5,2,4]) == [1,2,3,4,5]
-assert sorted([1,3,5,2,4], reverse=True) == [5,4,3,2,1]
+assert sorted([1,3,5,2,4]) == [1,2,3,4,5], "sorted([1,3,5,2,4])"
+#assert sorted([1,3,5,2,4], reverse=True) == [5,4,3,2,1], "sorted([1,3,5,2,4], reverse=True)"
+assert sorted("hello") == ["e","h","l","l","o"], 'sorted("hello")'
+assert sorted(range(5,1,-1)) == [2,3,4,5], 'sorted(range(5, 1, -1))'

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -1,0 +1,4 @@
+
+
+assert sorted([1,3,5,2,4]) == [1,2,3,4,5]
+assert sorted([1,3,5,2,4], reverse=True) == [5,4,3,2,1]

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -1,6 +1,27 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 assert sorted([1,3,5,2,4]) == [1,2,3,4,5], "sorted([1,3,5,2,4])"
-#assert sorted([1,3,5,2,4], reverse=True) == [5,4,3,2,1], "sorted([1,3,5,2,4], reverse=True)"
 assert sorted("hello") == ["e","h","l","l","o"], 'sorted("hello")'
 assert sorted(range(5,1,-1)) == [2,3,4,5], 'sorted(range(5, 1, -1))'
+
+# make sure that sorted does not modify the list
+l = [5,4,3,2,1]
+l_sorted = sorted(l)
+
+assert l == [5,4,3,2,1]
+assert l_sorted == [1,2,3,4,5]
+
+#assert sorted([1,3,5,2,4], reverse=True) == [5,4,3,2,1], "sorted([1,3,5,2,4], reverse=True)"


### PR DESCRIPTION
A simple implementation of the ```sorted()``` builtin function for issue #16  

It does not handle keyword arguments (for modifiers) like ```cmd```, ```key``` and ```reverse``` (it fails hard when any kwargs are provided)

Implementation is done by copying the first argument (handled as an iterable) to a new list and use the builtin method ```sort()``` on this new list.