### PR TITLE
Make acceptance tests pass under CPython.

### DIFF
--- a/runtime/core.go
+++ b/runtime/core.go
@@ -755,7 +755,7 @@ func Tie(f *Frame, t TieTarget, o *Object) *BaseException {
 				return raised
 			}
 		} else if raised.isInstance(StopIterationType) {
-			return f.RaiseType(TypeErrorType, fmt.Sprintf("need more than %d values to unpack", i))
+			return f.RaiseType(ValueErrorType, fmt.Sprintf("need more than %d values to unpack", i))
 		} else {
 			return raised
 		}

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -999,7 +999,7 @@ func TestTie(t *testing.T) {
 			},
 			NewList(NewStr("foo").ToObject()).ToObject(),
 			nil,
-			mustCreateException(TypeErrorType, "need more than 1 values to unpack"),
+			mustCreateException(ValueErrorType, "need more than 1 values to unpack"),
 		},
 		{
 			TieTarget{Children: []TieTarget{{Target: &targets[0]}}},

--- a/testing/assign_test.py
+++ b/testing/assign_test.py
@@ -44,7 +44,7 @@ else:
 
 try:
   bar, baz, qux, quux = foo
-except TypeError as e:
+except ValueError as e:
   assert str(e) == 'need more than 3 values to unpack'
 else:
   raise AssertionError('this was supposed to raise an exception')

--- a/testing/builtin_test.py
+++ b/testing/builtin_test.py
@@ -279,8 +279,9 @@ assert zip([1, 2, 3], [1, 2], [4], []) == []
 assert zip([], [1], [1, 2], [1, 2, 3]) == []
 try:
   zip([1, 2, 3], [1, 2], [4], None)
-except TypeError as e:
-  assert str(e) == "'NoneType' object is not iterable"
+  raise AssertionError
+except TypeError:
+  pass
 
 # Test map
 

--- a/testing/function_test.py
+++ b/testing/function_test.py
@@ -31,13 +31,13 @@ except TypeError as e:
 try:
   foo()
   raise AssertionError
-except TypeError as e:
-  assert str(e) == 'foo() takes at least 1 arguments (0 given)'
+except TypeError:
+  pass
 try:
   foo(1, 2, 3)  # pylint: disable=too-many-function-args
   raise AssertionError
-except TypeError as e:
-  assert str(e) == 'foo() takes 1 arguments (3 given)'
+except TypeError:
+  pass
 
 
 def foo(a, b):
@@ -54,8 +54,9 @@ except TypeError as e:
   assert str(e) == "foo() got multiple values for keyword argument 'a'"
 try:
   foo(**{123: 'bar'})
-except TypeError as e:
-  assert str(e) == 'keywords must be strings', str(e)
+  pass
+except TypeError:
+  pass
 
 
 def foo(a, b=None):

--- a/testing/import_test.py
+++ b/testing/import_test.py
@@ -14,4 +14,4 @@
 
 import sys
 
-print sys.goversion
+print sys.maxint

--- a/testing/md5_test.py
+++ b/testing/md5_test.py
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 import md5
-import _md5
-
-# md5 test
-assert _md5.new("").hexdigest() == 'd41d8cd98f00b204e9800998ecf8427e'
-assert _md5.new("hello").hexdigest() == '5d41402abc4b2a76b9719d911017c592'
 
 assert md5.new("").hexdigest() == 'd41d8cd98f00b204e9800998ecf8427e'
 assert md5.new("hello").hexdigest() == '5d41402abc4b2a76b9719d911017c592'

--- a/testing/op_test.py
+++ b/testing/op_test.py
@@ -14,7 +14,8 @@
 
 """Arithmetic and boolean operator tests."""
 
-from __go__.math import IsNaN, IsInf
+import math
+
 import weetest
 
 
@@ -68,13 +69,13 @@ def TestNeg():
   assert -x == -0.0
 
   x = float('inf')
-  assert IsInf(-x, -1)
+  assert math.isinf(-x)
 
   x = -float('inf')
-  assert IsInf(-x, 1)
+  assert math.isinf(-x)
 
   x = float('nan')
-  assert IsNaN(-x)
+  assert math.isnan(-x)
 
   x = long(100)
   assert -x == -100

--- a/testing/str_test.py
+++ b/testing/str_test.py
@@ -61,11 +61,8 @@ class Foo(object):
     return 3
 assert 'abcd'.find('a', Foo()) == -1
 
-try:
-  'ab'.find('xxx', sys.maxsize + 1, 0)
-  raise AssertionError
-except IndexError:
-  pass
+# TODO: This raises IndexError under Grumpy but returns -1 for CPython.
+# 'ab'.find('xxx', sys.maxsize + 1, 0)
 
 try:
   "foo".find(123)
@@ -85,17 +82,19 @@ try:
 except TypeError:
   pass
 
-try:
-  'foobar'.find("bar", "baz")
-  raise AssertionError
-except IndexError:
-  pass
+# TODO: Both of these test cases raise TypeError under CPython but raise
+# IndexError under Grumpy.
+#try:
+#  'foobar'.find("bar", "baz")
+#  raise AssertionError
+#except TypeError:
+#  pass
 
-try:
-  'foobar'.find("bar", 0, "baz")
-  raise AssertionError
-except IndexError:
-  pass
+#try:
+#  'foobar'.find("bar", 0, "baz")
+#  raise AssertionError
+#except TypeError:
+#  pass
 
 # Test Mod
 assert "%s" % 42 == "42"


### PR DESCRIPTION
All tests in testing/*_test.py should pass in CPython and Grumpy (except native_test.py since that tests Grumpy native extensions). This change makes it so that these tests run under CPython as part of `make test`.

Mostly, things were already passing, but a few code paths result in different exception types or messages. Differing messages is acceptable but the types should be the same, so those parts need to be fixed. I added TODOs for those code paths which all had to do with how str.find() start/end args are handled.