### PR TITLE
Add install section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,3 +244,19 @@ $(patsubst %,build/%.go,$(BENCHMARKS)): build/%.go: %.py $(COMPILER)
 $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME) $(STDLIB)
 	@mkdir -p $(@D)
 	@go build -o $@ $<
+
+# ------------------------------------------------------------------------------
+# Installation
+# ------------------------------------------------------------------------------
+
+install:
+	install -d $(DESTDIR)/usr/lib/go
+	install -d $(DESTDIR)/usr/bin
+	install -Dm755 tools/benchcmp $(DESTDIR)/usr/bin/benchcmp
+	install -Dm755 tools/coverparse $(DESTDIR)/usr/bin/coverparse
+	install -Dm755 tools/diffrange $(DESTDIR)/usr/bin/diffrange
+	install -Dm755 tools/grumpc $(DESTDIR)/usr/bin/grumpc
+	install -Dm755 tools/grumprun $(DESTDIR)/usr/bin/grumprun
+	cp -rv --no-preserve=ownership build/bin build/lib $(DESTDIR)/usr/
+	cp -rv --no-preserve=ownership build/pkg build/src $(DESTDIR)/usr/lib/go/
+

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: $(ACCEPT_PASS_FILES) $(ACCEPT_PY_PASS_FILES) $(COMPILER_PASS_FILES) $(COMP
 
 precommit: cover gofmt lint test
 
-.PHONY: all benchmarks clean cover gofmt golint lint precommit pylint run test install
+.PHONY: all benchmarks clean cover gofmt golint install lint precommit pylint run test
 
 # ------------------------------------------------------------------------------
 # grumpc compiler

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,13 @@ ifeq ($(PYTHON),)
 endif
 PYTHON_BIN := $(shell which $(PYTHON))
 PYTHON_VER := $(word 2,$(shell $(PYTHON) -V 2>&1))
-PY_DIR := build/lib/python2.7/site-packages
-PY_INSTALL_DIR := $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 ifeq ($(filter 2.7.%,$(PYTHON_VER)),)
   $(error unsupported Python version $(PYTHON_VER), Grumpy only supports 2.7.x. To use a different python binary such as python2, run: 'make PYTHON=python2 ...')
 endif
+
+PY_DIR := build/lib/python2.7/site-packages
+PY_INSTALL_DIR := $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 export GOPATH := $(ROOT_DIR)/build
 export PYTHONPATH := $(ROOT_DIR)/$(PY_DIR)

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: $(ACCEPT_PASS_FILES) $(ACCEPT_PY_PASS_FILES) $(COMPILER_PASS_FILES) $(COMP
 
 precommit: cover gofmt lint test
 
-.PHONY: all benchmarks clean cover gofmt golint lint precommit pylint run test
+.PHONY: all benchmarks clean cover gofmt golint lint precommit pylint run test install
 
 # ------------------------------------------------------------------------------
 # grumpc compiler
@@ -249,14 +249,10 @@ $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME
 # Installation
 # ------------------------------------------------------------------------------
 
-install:
+install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
+	install -Dm755 build/bin/grumpc $(DESTDIR)/usr/bin/grumpc
+	install -Dm755 build/bin/grumprun $(DESTDIR)/usr/bin/grumprun
 	install -d $(DESTDIR)/usr/lib/go
-	install -d $(DESTDIR)/usr/bin
-	install -Dm755 tools/benchcmp $(DESTDIR)/usr/bin/benchcmp
-	install -Dm755 tools/coverparse $(DESTDIR)/usr/bin/coverparse
-	install -Dm755 tools/diffrange $(DESTDIR)/usr/bin/diffrange
-	install -Dm755 tools/grumpc $(DESTDIR)/usr/bin/grumpc
-	install -Dm755 tools/grumprun $(DESTDIR)/usr/bin/grumprun
-	cp -rv --no-preserve=ownership build/bin build/lib $(DESTDIR)/usr/
+	cp -rv --no-preserve=ownership build/lib $(DESTDIR)/usr/
 	cp -rv --no-preserve=ownership build/pkg build/src $(DESTDIR)/usr/lib/go/
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 PYTHON_BIN := $(shell which $(PYTHON))
 PYTHON_VER := $(word 2,$(shell $(PYTHON) -V 2>&1))
 PY_DIR := build/lib/python2.7/site-packages
-PY_INSTALL_DIR := $(shell python2 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+PY_INSTALL_DIR := $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 ifeq ($(filter 2.7.%,$(PYTHON_VER)),)
   $(error unsupported Python version $(PYTHON_VER), Grumpy only supports 2.7.x. To use a different python binary such as python2, run: 'make PYTHON=python2 ...')

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ endif
 PYTHON_BIN := $(shell which $(PYTHON))
 PYTHON_VER := $(word 2,$(shell $(PYTHON) -V 2>&1))
 PY_DIR := build/lib/python2.7/site-packages
+PY_INSTALL_DIR := $(shell python2 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 ifeq ($(filter 2.7.%,$(PYTHON_VER)),)
   $(error unsupported Python version $(PYTHON_VER), Grumpy only supports 2.7.x. To use a different python binary such as python2, run: 'make PYTHON=python2 ...')
@@ -250,9 +251,12 @@ $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME
 # ------------------------------------------------------------------------------
 
 install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
-	install -Dm755 build/bin/grumpc $(DESTDIR)/usr/bin/grumpc
-	install -Dm755 build/bin/grumprun $(DESTDIR)/usr/bin/grumprun
-	install -d $(DESTDIR)/usr/lib/go
-	cp -rv --no-preserve=ownership build/lib $(DESTDIR)/usr/
-	cp -rv --no-preserve=ownership build/pkg build/src $(DESTDIR)/usr/lib/go/
+	# Binary executables
+	install -Dm755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
+	install -Dm755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
+	# Python module
+	install -d "$(DESTDIR)"{/usr/lib/go,"$(PY_INSTALL_DIR)"}
+	cp -rv --no-preserve=ownership "$(PY_DIR)/grumpy" "$(DESTDIR)$(PY_INSTALL_DIR)"
+	# Go package and sources
+	cp -rv --no-preserve=ownership build/pkg build/src "$(DESTDIR)/usr/lib/go/"
 


### PR DESCRIPTION
Added an `install` section to the Makefile.

It's not perfect, but it appears to work for [this unofficial Arch Linux package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=grumpy).

This change allows grumpy to be installed on the system and makes it easier to package for Linux maintainers.