### PR TITLE
Fix IndexError to TypeError

### DIFF
--- a/runtime/core.go
+++ b/runtime/core.go
@@ -501,7 +501,7 @@ func IndexInt(f *Frame, o *Object) (i int, raised *BaseException) {
 	if o.isInstance(LongType) {
 		l := toLongUnsafe(o).Value()
 		// Anything bigger than maxIntBig will treat as maxIntBig.
-		if maxIntBig.Cmp(l) < 0 {
+		if !numInIntRange(l) {
 			l = maxIntBig
 		}
 		return int(l.Int64()), nil

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -493,13 +493,14 @@ func IndexInt(f *Frame, o *Object) (int, *BaseException) {
 	if raised != nil {
 		return 0, raised
 	}
-	if i != nil {
-		if i.isInstance(IntType) {
-			return toIntUnsafe(i).Value(), nil
-		}
-		if l := toLongUnsafe(i).Value(); numInIntRange(l) {
-			return int(l.Int64()), nil
-		}
+	if i == nil || (!i.isInstance(IntType) && !i.isInstance(LongType)) {
+		return 0, f.RaiseType(TypeErrorType, "slice indices must be integers or None or have an __index__ method")
+	}
+	if i.isInstance(IntType) {
+		return toIntUnsafe(i).Value(), nil
+	}
+	if l := toLongUnsafe(i).Value(); numInIntRange(l) {
+		return int(l.Int64()), nil
 	}
 	return 0, f.RaiseType(IndexErrorType, fmt.Sprintf("cannot fit '%s' into an index-sized integer", o.typ))
 }

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -493,7 +493,7 @@ func IndexInt(f *Frame, o *Object) (int, *BaseException) {
 	if raised != nil {
 		return 0, raised
 	}
-	if i == nil || (!i.isInstance(IntType) && !i.isInstance(LongType)) {
+	if i == nil {
 		return 0, f.RaiseType(TypeErrorType, "slice indices must be integers or None or have an __index__ method")
 	}
 	if i.isInstance(IntType) {

--- a/runtime/slice.go
+++ b/runtime/slice.go
@@ -156,64 +156,6 @@ func initSliceType(map[string]*Object) {
 	SliceType.slots.Repr = &unaryOpSlot{sliceRepr}
 }
 
-func sliceIndex(f *Frame, o *Object) (i int, raised *BaseException) {
-	if index := o.typ.slots.Index; index != nil {
-		// Unwrap __index__ slot and fall through.
-		o, raised = index.Fn(f, o)
-		if raised != nil {
-			return 0, raised
-		}
-	}
-	if o.isInstance(IntType) {
-		return toIntUnsafe(o).Value(), nil
-	}
-	if o.isInstance(LongType) {
-		l := toLongUnsafe(o).Value()
-		// Anything bigger than maxIntBig will treat as maxIntBig.
-		if maxIntBig.Cmp(l) < 0 {
-			l = maxIntBig
-		}
-		return int(l.Int64()), nil
-	}
-	return 0, f.RaiseType(TypeErrorType, errBadSliceIndex)
-}
-
-func sliceGetIndices(f *Frame, oStart, oStop *Object, length int) (start, stop int, raised *BaseException) {
-	// TODO: Implement step
-	if oStart == None {
-		start = 0
-	} else {
-		start, raised = sliceIndex(f, oStart)
-		if raised != nil {
-			return
-		}
-		if start < 0 {
-			start += length
-		}
-		if start < 0 {
-			start = 0
-		}
-	}
-	if oStop == None {
-		stop = length
-	} else {
-		stop, raised = sliceIndex(f, oStop)
-		if raised != nil {
-			return
-		}
-		if stop < 0 {
-			stop += length
-		}
-		if stop < 0 {
-			stop = 0
-		}
-		if stop >= length {
-			stop = length
-		}
-	}
-	return
-}
-
 func sliceClampIndex(f *Frame, index *Object, def, seqLen int) (int, *BaseException) {
 	if index == nil || index == None {
 		return def, nil

--- a/runtime/str.go
+++ b/runtime/str.go
@@ -221,13 +221,13 @@ func strFind(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	s := toStrUnsafe(args[0]).Value()
 	l := len(s)
 	start, end := 0, l
-	if argc >= 3 {
+	if argc >= 3 && args[2] != None {
 		start, raised = IndexInt(f, args[2])
 		if raised != nil {
 			return nil, raised
 		}
 	}
-	if argc == 4 {
+	if argc == 4 && args[3] != None {
 		end, raised = IndexInt(f, args[3])
 		if raised != nil {
 			return nil, raised

--- a/runtime/str_test.go
+++ b/runtime/str_test.go
@@ -270,8 +270,10 @@ func TestStrMethods(t *testing.T) {
 		{"find", wrapArgs("foobar", "bar", NewInt(MaxInt)), NewInt(-1).ToObject(), nil},
 		// TODO: Support unicode substring.
 		{"find", wrapArgs("foobar", NewUnicode("bar")), nil, mustCreateException(TypeErrorType, "'find/index' requires a 'str' object but received a 'unicode'")},
-		{"find", wrapArgs("foobar", "bar", "baz"), nil, mustCreateException(IndexErrorType, "cannot fit '<type 'str'>' into an index-sized integer")},
-		{"find", wrapArgs("foobar", "bar", 0, "baz"), nil, mustCreateException(IndexErrorType, "cannot fit '<type 'str'>' into an index-sized integer")},
+		{"find", wrapArgs("foobar", "bar", "baz"), nil, mustCreateException(TypeErrorType, "slice indices must be integers or None or have an __index__ method")},
+		{"find", wrapArgs("foobar", "bar", 0, "baz"), nil, mustCreateException(TypeErrorType, "slice indices must be integers or None or have an __index__ method")},
+		{"find", wrapArgs("foobar", "bar", None), NewInt(3).ToObject(), nil},
+		{"find", wrapArgs("foobar", "bar", 0, None), NewInt(3).ToObject(), nil},
 		{"find", wrapArgs("foobar", "bar", 0, -2), NewInt(-1).ToObject(), nil},
 		{"find", wrapArgs("foobar", "foo", 0, 3), NewInt(0).ToObject(), nil},
 		{"find", wrapArgs("foobar", "foo", 10), NewInt(-1).ToObject(), nil},

--- a/runtime/str_test.go
+++ b/runtime/str_test.go
@@ -247,6 +247,7 @@ func TestStrRepr(t *testing.T) {
 }
 
 func TestStrMethods(t *testing.T) {
+	fooType := newTestClass("Foo", []*Type{ObjectType}, newStringDict(map[string]*Object{"bar": None}))
 	cases := []struct {
 		methodName string
 		args       Args
@@ -269,6 +270,7 @@ func TestStrMethods(t *testing.T) {
 		{"find", wrapArgs("", "", -1), NewInt(0).ToObject(), nil},
 		{"find", wrapArgs("", "", None, -1), NewInt(0).ToObject(), nil},
 		{"find", wrapArgs("foobar", "bar"), NewInt(3).ToObject(), nil},
+		{"find", wrapArgs("foobar", "bar", fooType), nil, mustCreateException(TypeErrorType, "slice indices must be integers or None or have an __index__ method")},
 		{"find", wrapArgs("foobar", "bar", NewInt(MaxInt)), NewInt(-1).ToObject(), nil},
 		// TODO: Support unicode substring.
 		{"find", wrapArgs("foobar", NewUnicode("bar")), nil, mustCreateException(TypeErrorType, "'find/index' requires a 'str' object but received a 'unicode'")},

--- a/runtime/str_test.go
+++ b/runtime/str_test.go
@@ -266,6 +266,8 @@ func TestStrMethods(t *testing.T) {
 		{"endswith", wrapArgs("foo", newTestTuple(123).ToObject()), nil, mustCreateException(TypeErrorType, "expected a str")},
 		{"find", wrapArgs("", ""), NewInt(0).ToObject(), nil},
 		{"find", wrapArgs("", "", 1), NewInt(-1).ToObject(), nil},
+		{"find", wrapArgs("", "", -1), NewInt(0).ToObject(), nil},
+		{"find", wrapArgs("", "", None, -1), NewInt(0).ToObject(), nil},
 		{"find", wrapArgs("foobar", "bar"), NewInt(3).ToObject(), nil},
 		{"find", wrapArgs("foobar", "bar", NewInt(MaxInt)), NewInt(-1).ToObject(), nil},
 		// TODO: Support unicode substring.

--- a/testing/str_test.py
+++ b/testing/str_test.py
@@ -24,6 +24,8 @@ assert "baz" + "" == "baz"
 # Test find
 assert "".find("") == 0
 assert "".find("", 1) == -1
+assert "".find("", -1) == 0
+assert "".find("", None, -1) == 0
 assert "foobar".find("bar") == 3
 assert "foobar".find("bar", 0, -2) == -1
 assert "foobar".find("foo", 0, 3) == 0
@@ -44,18 +46,17 @@ assert 'abc'.find('', 4) == -1
 assert 'rrarrrrrrrrra'.find('a') == 2
 assert 'rrarrrrrrrrra'.find('a', 4) == 12
 assert 'rrarrrrrrrrra'.find('a', 4, 6) == -1
+assert 'rrarrrrrrrrra'.find('a', 4, None) == 12
+assert 'rrarrrrrrrrra'.find('a', None, 6) == 2
 assert ''.find('') == 0
 assert ''.find('', 1, 1) == -1
 assert ''.find('', sys.maxint, 0) == -1
 assert ''.find('xx') == -1
 assert ''.find('xx', 1, 1) == -1
 assert ''.find('xx', sys.maxint, 0) == -1
+assert 'ab'.find('xxx', sys.maxsize + 1, 0) == -1
 # TODO: Support unicode substring.
 # assert "foobar".find(u"bar") == 3
-# TODO: Support None.
-# assert 'rrarrrrrrrrra'.find('a', 4, None) == 12
-# assert 'rrarrrrrrrrra'.find('a', None, 6) == 2
-
 
 class Foo(object):
 
@@ -63,8 +64,6 @@ class Foo(object):
     return 3
 assert 'abcd'.find('a', Foo()) == -1
 
-# TODO: This raises IndexError under Grumpy but returns -1 for CPython.
-# 'ab'.find('xxx', sys.maxsize + 1, 0)
 
 try:
   "foo".find(123)

--- a/testing/str_test.py
+++ b/testing/str_test.py
@@ -29,6 +29,8 @@ assert "foobar".find("bar", 0, -2) == -1
 assert "foobar".find("foo", 0, 3) == 0
 assert "foobar".find("bar", 3, 5) == -1
 assert "foobar".find("bar", 5, 3) == -1
+assert 'foobar'.find("bar", None) == 3
+assert 'foobar'.find("bar", 0, None) == 3
 assert "bar".find("foobar") == -1
 assert "bar".find("a", 0, -1) == 1
 assert 'abcdefghiabc'.find('abc') == 0
@@ -82,19 +84,17 @@ try:
 except TypeError:
   pass
 
-# TODO: Both of these test cases raise TypeError under CPython but raise
-# IndexError under Grumpy.
-#try:
-#  'foobar'.find("bar", "baz")
-#  raise AssertionError
-#except TypeError:
-#  pass
+try:
+  'foobar'.find("bar", "baz")
+  raise AssertionError
+except TypeError:
+  pass
 
-#try:
-#  'foobar'.find("bar", 0, "baz")
-#  raise AssertionError
-#except TypeError:
-#  pass
+try:
+  'foobar'.find("bar", 0, "baz")
+  raise AssertionError
+except TypeError:
+  pass
 
 # Test Mod
 assert "%s" % 42 == "42"


### PR DESCRIPTION
- Supposed to fix IndexError to TypeError except int, long or with `__index__` method.
- Added passing None to start or end, which supposed to take as default values.
- Note that sys.maxsize + 1 issue is not yet fixed.
