### PR TITLE
Check if python2 exists before defaulting to python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,15 @@ GOOS ?= $(word 1,$(GO_ENV))
 GOARCH ?= $(word 2,$(GO_ENV))
 ROOT_DIR := $(realpath .)
 PKG_DIR := build/pkg/$(GOOS)_$(GOARCH)
-PYTHON ?= python
+
+# Try python2 and then python if PYTHON has not been set
+ifeq ($(PYTHON),)
+  ifneq ($(shell which python2),)
+    PYTHON = python2
+  else
+    PYTHON = python
+  endif
+endif
 PYTHON_BIN := $(shell which $(PYTHON))
 PYTHON_VER := $(word 2,$(shell $(PYTHON) -V 2>&1))
 PY_DIR := build/lib/python2.7/site-packages


### PR DESCRIPTION
Many distros use `python` as the default and latest version of Python (version 3.x), while Python 2.x is `python2`.

With this pull request, if `PYTHON` has not been defined, there is a check in place for if `python2` is in the path. If not, it falls back to `python`, like before (`PYTHON ?= python`).