### PR TITLE
Fix a bug in os.path.basename and implement os.path.split

### DIFF
--- a/lib/os/path.py
+++ b/lib/os/path.py
@@ -15,7 +15,7 @@
 """"Utilities for manipulating and inspecting OS paths."""
 
 from __go__.os import Stat
-from __go__.path.filepath import Abs, Base as basename, Clean, Dir as dirname, IsAbs as isabs, Join  # pylint: disable=g-multiple-import,unused-import
+from __go__.path.filepath import Abs, Base, Clean, Dir as dirname, IsAbs as isabs, Join, Split  # pylint: disable=g-multiple-import,unused-import
 
 
 def abspath(path):
@@ -27,6 +27,10 @@ def abspath(path):
     # decoded using utf-8.
     return unicode(result, 'utf-8')
   return result
+
+
+def basename(path):
+  return '' if path.endswith('/') else Base(path)
 
 
 def exists(path):
@@ -73,3 +77,10 @@ def normpath(path):
   if isinstance(path, unicode):
     return unicode(result, 'utf-8')
   return result
+
+
+def split(path):
+  head, tail = Split(path)
+  if len(head) > 1 and head[-1] == '/':
+    head = head[:-1]
+  return (head, tail)

--- a/lib/os/path_test.py
+++ b/lib/os/path_test.py
@@ -35,6 +35,11 @@ def TestAbspath():
   _AssertEqual(path.abspath('a/b/c'), path.normpath(os.getcwd() + '/a/b/c'))
 
 
+def TestBasename():
+  assert path.basename('/a/b/c') == 'c'
+  assert path.basename('/a/b/c/') == ''
+
+
 def TestDirname():
   assert path.dirname('/a/b/c') == '/a/b'
   assert path.dirname('/a/b/c/') == '/a/b/c'
@@ -108,6 +113,15 @@ def TestNormPath():
   _AssertEqual(path.normpath(u'abc/../123'), u'123')
   _AssertEqual(path.normpath(u'../abc/123'), u'../abc/123')
   _AssertEqual(path.normpath(u'x/y/./z'), u'x/y/z')
+
+
+def TestSplit():
+  assert path.split('a/b') == ('a', 'b')
+  assert path.split('a/b/') == ('a/b', '')
+  assert path.split('a/') == ('a', '')
+  assert path.split('a') == ('', 'a')
+  assert path.split('/') == ('/', '')
+  assert path.split('/a/./b') == ('/a/.', 'b')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Behaviors of `os.path.basename` and `filepath.Base` are different. Consider `"/a/b/c/"`: `basename` return `''` but `Base` return `'c'`.

Also, there are some slightly differences between  b`os.path.split` and `filepath.Split`. 

Signed-off-by: Cholerae Hu <choleraehyq@gmail.com>