### PR TITLE
Minor changes to make CPython sequence tests pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,26 @@ THIRD_PARTY_STDLIB_PACKAGES := $(foreach x,$(THIRD_PARTY_STDLIB_SRCS),$(patsubst
 STDLIB_SRCS := $(GRUMPY_STDLIB_SRCS) $(THIRD_PARTY_STDLIB_SRCS)
 STDLIB_PACKAGES := $(GRUMPY_STDLIB_PACKAGES) $(THIRD_PARTY_STDLIB_PACKAGES)
 STDLIB := $(patsubst %,$(PKG_DIR)/grumpy/lib/%.a,$(STDLIB_PACKAGES))
-STDLIB_TESTS := $(patsubst lib/%.py,%,$(shell find lib -name '*_test.py'))
-STDLIB_PASS_FILES := $(patsubst %,$(PKG_DIR)/grumpy/lib/%.pass,$(STDLIB_TESTS))
+LIB_TEST_SRCS := \
+  lib/itertools_test.py \
+  lib/math_test.py \
+  lib/os/path_test.py \
+  lib/os_test.py \
+  lib/random_test.py \
+  lib/sys_test.py \
+  lib/tempfile_test.py \
+  lib/threading_test.py \
+  lib/time_test.py \
+  lib/types_test.py \
+  lib/weetest_test.py
+LIB_PASS_FILES := $(patsubst %.py,$(PKG_DIR)/grumpy/%.pass,$(LIB_TEST_SRCS))
+CPYTHON_TEST_SRCS := \
+  third_party/stdlib/re_tests.py \
+  third_party/stdlib/test/seq_tests.py \
+  third_party/stdlib/test/test_support.py \
+  third_party/stdlib/test/test_tuple.py
+CPYTHON_PASS_FILES := $(patsubst third_party/stdlib/%.py,$(PKG_DIR)/grumpy/lib/%.pass,$(CPYTHON_TEST_SRCS))
+STDLIB_PASS_FILES := $(LIB_PASS_FILES) $(CPYTHON_PASS_FILES)
 
 ACCEPT_TESTS := $(patsubst %.py,%,$(wildcard testing/*.py))
 ACCEPT_PASS_FILES := $(patsubst %,build/%.pass,$(ACCEPT_TESTS))

--- a/runtime/seq.go
+++ b/runtime/seq.go
@@ -64,13 +64,15 @@ func seqCompare(f *Frame, elems1, elems2 []*Object, cmp binaryOpFunc) (*Object, 
 // object.
 func seqApply(f *Frame, seq *Object, fun func([]*Object, bool) *BaseException) *BaseException {
 	switch {
-	case seq.isInstance(ListType):
+	// Don't use fast path referencing the underlying slice directly for
+	// list and tuple subtypes. See comment in listextend in listobject.c.
+	case seq.typ == ListType:
 		l := toListUnsafe(seq)
 		l.mutex.RLock()
 		raised := fun(l.elems, true)
 		l.mutex.RUnlock()
 		return raised
-	case seq.isInstance(TupleType):
+	case seq.typ == TupleType:
 		return fun(toTupleUnsafe(seq).elems, true)
 	default:
 		elems := []*Object{}

--- a/runtime/tuple.go
+++ b/runtime/tuple.go
@@ -138,6 +138,10 @@ func tupleNE(f *Frame, v, w *Object) (*Object, *BaseException) {
 }
 
 func tupleNew(f *Frame, t *Type, args Args, _ KWArgs) (*Object, *BaseException) {
+	if t == TupleType && len(args) == 1 && args[0].typ == TupleType {
+		// Tuples are immutable so just return the tuple provided.
+		return args[0], nil
+	}
 	elems, raised := seqNew(f, args)
 	if raised != nil {
 		return nil, raised


### PR DESCRIPTION
Also updated Makefile to include these tests in the "make test" suite.
It became awkward to automatically detect the .py test files (they don't
really follow any particular naming convention) so they're listed
explicitly. To make things easier to follow I also listed out the other
stdlib test files explicitly. Long term I think we should be listing all
files this way (including .go sources) so that things are less magical.