### PR TITLE
Implement Decorators

### DIFF
--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -212,6 +212,17 @@ class StatementVisitorTest(unittest.TestCase):
         util.ParseError, "'continue' not in loop",
         _ParseAndVisit, 'for i in (1,):\n  pass\nelse:\n  continue')
 
+  def testFunctionDecorator(self):
+    self.assertEqual((0, '<b>foo</b>\n'), _GrumpRun(textwrap.dedent("""\
+        def bold(fn):
+          def wrapped():
+            return '<b>' + fn() + '</b>'
+          return wrapped
+        @bold
+        def foo():
+          return 'foo'
+        print foo()""")))
+
   def testFunctionDef(self):
     self.assertEqual((0, 'bar baz\n'), _GrumpRun(textwrap.dedent("""\
         def foo(a, b):

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -215,10 +215,19 @@ class StatementVisitorTest(unittest.TestCase):
   def testFunctionDecorator(self):
     self.assertEqual((0, '<b>foo</b>\n'), _GrumpRun(textwrap.dedent("""\
         def bold(fn):
-          def wrapped():
-            return '<b>' + fn() + '</b>'
-          return wrapped
+          return lambda: '<b>' + fn() + '</b>'
         @bold
+        def foo():
+          return 'foo'
+        print foo()""")))
+
+  def testFunctionDecoratorWithArg(self):
+    self.assertEqual((0, '<b id=red>foo</b>\n'), _GrumpRun(textwrap.dedent("""\
+        def tag(name):
+          def bold(fn):
+            return lambda: '<b id=' + name + '>' + fn() + '</b>'
+          return bold
+        @tag('red')
         def foo():
           return 'foo'
         print foo()""")))


### PR DESCRIPTION
This is for #72, but I guess this implementation may be more a like a hack, because Instead of generating Go code, I triggered AST to add more nodes while walking through.

- Confirmed simple decorators working, not sure there is some complex use cases.
- This is only for function decorators, class decorators not yet supported.
(I don't get this syntax for class working yet. `C = decorator(C)`)

```
% make run
def bold(fn):
    def wrapped():
        return "<b>" + fn() + "</b>"
    return wrapped

def italic(fn):
    def wrapped():
        return "<i>" + fn() + "</i>"
    return wrapped

@bold
@italic
def hello():
    return "hello world"

print hello()
```
```
<b><i>hello world</i></b>
```

```
import contextlib

@contextlib.contextmanager
def tag(name):
    print "<%s>" % name
    yield
    print "</%s>" % name

with tag("h1"):
  print "foo"
```
```
<h1>
foo
</h1>
```
