### PR TITLE
Add CPython dict tests

### DIFF
--- a/third_party/stdlib/contextlib.py
+++ b/third_party/stdlib/contextlib.py
@@ -23,8 +23,8 @@ class GeneratorContextManager(object):
         except StopIteration:
             raise RuntimeError("generator didn't yield")
 
-    def __exit__(self, type, value, traceback):
-        if type is None:
+    def __exit__(self, t, value, tb):
+        if t is None:
             try:
                 self.gen.next()
             except StopIteration:
@@ -35,10 +35,11 @@ class GeneratorContextManager(object):
             if value is None:
                 # Need to force instantiation so we can reliably
                 # tell if we get the same exception back
-                value = type()
+                value = t()
             try:
-                self.gen.throw(type, value, traceback)
-                raise RuntimeError("generator didn't stop after throw()")
+                # self.gen.throw(t, value, traceback)
+                # raise RuntimeError("generator didn't stop after throw()")
+                raise t(value)
             except StopIteration, exc:
                 # Suppress the exception *unless* it's the same exception that
                 # was passed to throw().  This prevents a StopIteration

--- a/third_party/stdlib/test/mapping_tests.py
+++ b/third_party/stdlib/test/mapping_tests.py
@@ -1,0 +1,687 @@
+# tests common to dict and UserDict
+import unittest
+import UserDict
+from test import test_support
+
+
+class BasicTestMappingProtocol(unittest.TestCase):
+    # This base class can be used to check that an object conforms to the
+    # mapping protocol
+
+    # Functions that can be useful to override to adapt to dictionary
+    # semantics
+    type2test = None # which class is being tested (overwrite in subclasses)
+
+    def _reference(self):
+        """Return a dictionary of values which are invariant by storage
+        in the object under test."""
+        return {1:2, "key1":"value1", "key2":(1,2,3)}
+    def _empty_mapping(self):
+        """Return an empty mapping object"""
+        return self.type2test()
+    def _full_mapping(self, data):
+        """Return a mapping object with the value contained in data
+        dictionary"""
+        x = self._empty_mapping()
+        for key, value in data.items():
+            x[key] = value
+        return x
+
+    def __init__(self, *args, **kw):
+        unittest.TestCase.__init__(self, *args, **kw)
+        self.reference = self._reference().copy()
+
+        # A (key, value) pair not in the mapping
+        key, value = self.reference.popitem()
+        self.other = {key:value}
+
+        # A (key, value) pair in the mapping
+        key, value = self.reference.popitem()
+        self.inmapping = {key:value}
+        self.reference[key] = value
+
+    def test_read(self):
+        # Test for read only operations on mapping
+        p = self._empty_mapping()
+        p1 = dict(p) #workaround for singleton objects
+        d = self._full_mapping(self.reference)
+        if d is p:
+            p = p1
+        #Indexing
+        for key, value in self.reference.items():
+            self.assertEqual(d[key], value)
+        knownkey = self.other.keys()[0]
+        self.assertRaises(KeyError, lambda:d[knownkey])
+        #len
+        self.assertEqual(len(p), 0)
+        self.assertEqual(len(d), len(self.reference))
+        #in
+        for k in self.reference:
+            self.assertIn(k, d)
+        for k in self.other:
+            self.assertNotIn(k, d)
+        #has_key
+        with test_support.check_py3k_warnings(quiet=True):
+            for k in self.reference:
+                self.assertTrue(d.has_key(k))
+            for k in self.other:
+                self.assertFalse(d.has_key(k))
+        #cmp
+        self.assertEqual(cmp(p,p), 0)
+        self.assertEqual(cmp(d,d), 0)
+        self.assertEqual(cmp(p,d), -1)
+        self.assertEqual(cmp(d,p), 1)
+        #__non__zero__
+        if p: self.fail("Empty mapping must compare to False")
+        if not d: self.fail("Full mapping must compare to True")
+        # keys(), items(), iterkeys() ...
+        def check_iterandlist(iter, lst, ref):
+            self.assertTrue(hasattr(iter, 'next'))
+            self.assertTrue(hasattr(iter, '__iter__'))
+            x = list(iter)
+            self.assertTrue(set(x)==set(lst)==set(ref))
+        check_iterandlist(d.iterkeys(), d.keys(), self.reference.keys())
+        check_iterandlist(iter(d), d.keys(), self.reference.keys())
+        check_iterandlist(d.itervalues(), d.values(), self.reference.values())
+        check_iterandlist(d.iteritems(), d.items(), self.reference.items())
+        #get
+        key, value = d.iteritems().next()
+        knownkey, knownvalue = self.other.iteritems().next()
+        self.assertEqual(d.get(key, knownvalue), value)
+        self.assertEqual(d.get(knownkey, knownvalue), knownvalue)
+        self.assertNotIn(knownkey, d)
+
+    def test_write(self):
+        # Test for write operations on mapping
+        p = self._empty_mapping()
+        #Indexing
+        for key, value in self.reference.items():
+            p[key] = value
+            self.assertEqual(p[key], value)
+        for key in self.reference.keys():
+            del p[key]
+            self.assertRaises(KeyError, lambda:p[key])
+        p = self._empty_mapping()
+        #update
+        p.update(self.reference)
+        self.assertEqual(dict(p), self.reference)
+        items = p.items()
+        p = self._empty_mapping()
+        p.update(items)
+        self.assertEqual(dict(p), self.reference)
+        d = self._full_mapping(self.reference)
+        #setdefault
+        key, value = d.iteritems().next()
+        knownkey, knownvalue = self.other.iteritems().next()
+        self.assertEqual(d.setdefault(key, knownvalue), value)
+        self.assertEqual(d[key], value)
+        self.assertEqual(d.setdefault(knownkey, knownvalue), knownvalue)
+        self.assertEqual(d[knownkey], knownvalue)
+        #pop
+        self.assertEqual(d.pop(knownkey), knownvalue)
+        self.assertNotIn(knownkey, d)
+        self.assertRaises(KeyError, d.pop, knownkey)
+        default = 909
+        d[knownkey] = knownvalue
+        self.assertEqual(d.pop(knownkey, default), knownvalue)
+        self.assertNotIn(knownkey, d)
+        self.assertEqual(d.pop(knownkey, default), default)
+        #popitem
+        key, value = d.popitem()
+        self.assertNotIn(key, d)
+        self.assertEqual(value, self.reference[key])
+        p=self._empty_mapping()
+        self.assertRaises(KeyError, p.popitem)
+
+    def test_constructor(self):
+        self.assertEqual(self._empty_mapping(), self._empty_mapping())
+
+    def test_bool(self):
+        self.assertTrue(not self._empty_mapping())
+        self.assertTrue(self.reference)
+        self.assertTrue(bool(self._empty_mapping()) is False)
+        self.assertTrue(bool(self.reference) is True)
+
+    def test_keys(self):
+        d = self._empty_mapping()
+        self.assertEqual(d.keys(), [])
+        d = self.reference
+        self.assertIn(self.inmapping.keys()[0], d.keys())
+        self.assertNotIn(self.other.keys()[0], d.keys())
+        self.assertRaises(TypeError, d.keys, None)
+
+    def test_values(self):
+        d = self._empty_mapping()
+        self.assertEqual(d.values(), [])
+
+        self.assertRaises(TypeError, d.values, None)
+
+    def test_items(self):
+        d = self._empty_mapping()
+        self.assertEqual(d.items(), [])
+
+        self.assertRaises(TypeError, d.items, None)
+
+    def test_len(self):
+        d = self._empty_mapping()
+        self.assertEqual(len(d), 0)
+
+    def test_getitem(self):
+        d = self.reference
+        self.assertEqual(d[self.inmapping.keys()[0]], self.inmapping.values()[0])
+
+        self.assertRaises(TypeError, d.__getitem__)
+
+    def test_update(self):
+        # mapping argument
+        d = self._empty_mapping()
+        d.update(self.other)
+        self.assertEqual(d.items(), self.other.items())
+
+        # No argument
+        d = self._empty_mapping()
+        d.update()
+        self.assertEqual(d, self._empty_mapping())
+
+        # item sequence
+        d = self._empty_mapping()
+        d.update(self.other.items())
+        self.assertEqual(d.items(), self.other.items())
+
+        # Iterator
+        d = self._empty_mapping()
+        d.update(self.other.iteritems())
+        self.assertEqual(d.items(), self.other.items())
+
+        # FIXME: Doesn't work with UserDict
+        # self.assertRaises((TypeError, AttributeError), d.update, None)
+        self.assertRaises((TypeError, AttributeError), d.update, 42)
+
+        outerself = self
+        class SimpleUserDict:
+            def __init__(self):
+                self.d = outerself.reference
+            def keys(self):
+                return self.d.keys()
+            def __getitem__(self, i):
+                return self.d[i]
+        d.clear()
+        d.update(SimpleUserDict())
+        i1 = d.items()
+        i2 = self.reference.items()
+
+        def safe_sort_key(kv):
+            k, v = kv
+            return id(type(k)), id(type(v)), k, v
+        i1.sort(key=safe_sort_key)
+        i2.sort(key=safe_sort_key)
+        self.assertEqual(i1, i2)
+
+        class Exc(Exception): pass
+
+        d = self._empty_mapping()
+        class FailingUserDict:
+            def keys(self):
+                raise Exc
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        d.clear()
+
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = 1
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i:
+                            self.i = 0
+                            return 'a'
+                        raise Exc
+                return BogonIter()
+            def __getitem__(self, key):
+                return key
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        class FailingUserDict:
+            def keys(self):
+                class BogonIter:
+                    def __init__(self):
+                        self.i = ord('a')
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i <= ord('z'):
+                            rtn = chr(self.i)
+                            self.i += 1
+                            return rtn
+                        raise StopIteration
+                return BogonIter()
+            def __getitem__(self, key):
+                raise Exc
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        d = self._empty_mapping()
+        class badseq(object):
+            def __iter__(self):
+                return self
+            def next(self):
+                raise Exc()
+
+        self.assertRaises(Exc, d.update, badseq())
+
+        self.assertRaises(ValueError, d.update, [(1, 2, 3)])
+
+    # no test_fromkeys or test_copy as both os.environ and selves don't support it
+
+    def test_get(self):
+        d = self._empty_mapping()
+        self.assertTrue(d.get(self.other.keys()[0]) is None)
+        self.assertEqual(d.get(self.other.keys()[0], 3), 3)
+        d = self.reference
+        self.assertTrue(d.get(self.other.keys()[0]) is None)
+        self.assertEqual(d.get(self.other.keys()[0], 3), 3)
+        self.assertEqual(d.get(self.inmapping.keys()[0]), self.inmapping.values()[0])
+        self.assertEqual(d.get(self.inmapping.keys()[0], 3), self.inmapping.values()[0])
+        self.assertRaises(TypeError, d.get)
+        self.assertRaises(TypeError, d.get, None, None, None)
+
+    def test_setdefault(self):
+        d = self._empty_mapping()
+        self.assertRaises(TypeError, d.setdefault)
+
+    def test_popitem(self):
+        d = self._empty_mapping()
+        self.assertRaises(KeyError, d.popitem)
+        self.assertRaises(TypeError, d.popitem, 42)
+
+    def test_pop(self):
+        d = self._empty_mapping()
+        k, v = self.inmapping.items()[0]
+        d[k] = v
+        self.assertRaises(KeyError, d.pop, self.other.keys()[0])
+
+        self.assertEqual(d.pop(k), v)
+        self.assertEqual(len(d), 0)
+
+        self.assertRaises(KeyError, d.pop, k)
+
+
+class TestMappingProtocol(BasicTestMappingProtocol):
+    def test_constructor(self):
+        BasicTestMappingProtocol.test_constructor(self)
+        self.assertTrue(self._empty_mapping() is not self._empty_mapping())
+        self.assertEqual(self.type2test(x=1, y=2), {"x": 1, "y": 2})
+
+    def test_bool(self):
+        BasicTestMappingProtocol.test_bool(self)
+        self.assertTrue(not self._empty_mapping())
+        self.assertTrue(self._full_mapping({"x": "y"}))
+        self.assertTrue(bool(self._empty_mapping()) is False)
+        self.assertTrue(bool(self._full_mapping({"x": "y"})) is True)
+
+    def test_keys(self):
+        BasicTestMappingProtocol.test_keys(self)
+        d = self._empty_mapping()
+        self.assertEqual(d.keys(), [])
+        d = self._full_mapping({'a': 1, 'b': 2})
+        k = d.keys()
+        self.assertIn('a', k)
+        self.assertIn('b', k)
+        self.assertNotIn('c', k)
+
+    def test_values(self):
+        BasicTestMappingProtocol.test_values(self)
+        d = self._full_mapping({1:2})
+        self.assertEqual(d.values(), [2])
+
+    def test_items(self):
+        BasicTestMappingProtocol.test_items(self)
+
+        d = self._full_mapping({1:2})
+        self.assertEqual(d.items(), [(1, 2)])
+
+    def test_has_key(self):
+        d = self._empty_mapping()
+        self.assertTrue(not d.has_key('a'))
+        d = self._full_mapping({'a': 1, 'b': 2})
+        k = d.keys()
+        k.sort(key=lambda k: (id(type(k)), k))
+        self.assertEqual(k, ['a', 'b'])
+
+        self.assertRaises(TypeError, d.has_key)
+
+    def test_contains(self):
+        d = self._empty_mapping()
+        self.assertNotIn('a', d)
+        self.assertTrue(not ('a' in d))
+        self.assertTrue('a' not in d)
+        d = self._full_mapping({'a': 1, 'b': 2})
+        self.assertIn('a', d)
+        self.assertIn('b', d)
+        self.assertNotIn('c', d)
+
+        self.assertRaises(TypeError, d.__contains__)
+
+    def test_len(self):
+        BasicTestMappingProtocol.test_len(self)
+        d = self._full_mapping({'a': 1, 'b': 2})
+        self.assertEqual(len(d), 2)
+
+    def test_getitem(self):
+        BasicTestMappingProtocol.test_getitem(self)
+        d = self._full_mapping({'a': 1, 'b': 2})
+        self.assertEqual(d['a'], 1)
+        self.assertEqual(d['b'], 2)
+        d['c'] = 3
+        d['a'] = 4
+        self.assertEqual(d['c'], 3)
+        self.assertEqual(d['a'], 4)
+        del d['b']
+        self.assertEqual(d, {'a': 4, 'c': 3})
+
+        self.assertRaises(TypeError, d.__getitem__)
+
+    def test_clear(self):
+        d = self._full_mapping({1:1, 2:2, 3:3})
+        d.clear()
+        self.assertEqual(d, {})
+
+        self.assertRaises(TypeError, d.clear, None)
+
+    def test_update(self):
+        BasicTestMappingProtocol.test_update(self)
+        # mapping argument
+        d = self._empty_mapping()
+        d.update({1:100})
+        d.update({2:20})
+        d.update({1:1, 2:2, 3:3})
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        # no argument
+        d.update()
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        # keyword arguments
+        d = self._empty_mapping()
+        d.update(x=100)
+        d.update(y=20)
+        d.update(x=1, y=2, z=3)
+        self.assertEqual(d, {"x":1, "y":2, "z":3})
+
+        # item sequence
+        d = self._empty_mapping()
+        d.update([("x", 100), ("y", 20)])
+        self.assertEqual(d, {"x":100, "y":20})
+
+        # Both item sequence and keyword arguments
+        d = self._empty_mapping()
+        d.update([("x", 100), ("y", 20)], x=1, y=2)
+        self.assertEqual(d, {"x":1, "y":2})
+
+        # iterator
+        d = self._full_mapping({1:3, 2:4})
+        d.update(self._full_mapping({1:2, 3:4, 5:6}).iteritems())
+        self.assertEqual(d, {1:2, 2:4, 3:4, 5:6})
+
+        class SimpleUserDict:
+            def __init__(self):
+                self.d = {1:1, 2:2, 3:3}
+            def keys(self):
+                return self.d.keys()
+            def __getitem__(self, i):
+                return self.d[i]
+        d.clear()
+        d.update(SimpleUserDict())
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+    def test_fromkeys(self):
+        self.assertEqual(self.type2test.fromkeys('abc'), {'a':None, 'b':None, 'c':None})
+        d = self._empty_mapping()
+        self.assertTrue(not(d.fromkeys('abc') is d))
+        self.assertEqual(d.fromkeys('abc'), {'a':None, 'b':None, 'c':None})
+        self.assertEqual(d.fromkeys((4,5),0), {4:0, 5:0})
+        self.assertEqual(d.fromkeys([]), {})
+        def g():
+            yield 1
+        self.assertEqual(d.fromkeys(g()), {1:None})
+        self.assertRaises(TypeError, {}.fromkeys, 3)
+        class dictlike(self.type2test): pass
+        self.assertEqual(dictlike.fromkeys('a'), {'a':None})
+        self.assertEqual(dictlike().fromkeys('a'), {'a':None})
+        self.assertTrue(dictlike.fromkeys('a').__class__ is dictlike)
+        self.assertTrue(dictlike().fromkeys('a').__class__ is dictlike)
+        # FIXME: the following won't work with UserDict, because it's an old style class
+        # self.assertTrue(type(dictlike.fromkeys('a')) is dictlike)
+        class mydict(self.type2test):
+            def __new__(cls):
+                return UserDict.UserDict()
+        ud = mydict.fromkeys('ab')
+        self.assertEqual(ud, {'a':None, 'b':None})
+        # FIXME: the following won't work with UserDict, because it's an old style class
+        # self.assertIsInstance(ud, UserDict.UserDict)
+        self.assertRaises(TypeError, dict.fromkeys)
+
+        class Exc(Exception): pass
+
+        class baddict1(self.type2test):
+            def __init__(self):
+                raise Exc()
+
+        self.assertRaises(Exc, baddict1.fromkeys, [1])
+
+        class BadSeq(object):
+            def __iter__(self):
+                return self
+            def next(self):
+                raise Exc()
+
+        self.assertRaises(Exc, self.type2test.fromkeys, BadSeq())
+
+        class baddict2(self.type2test):
+            def __setitem__(self, key, value):
+                raise Exc()
+
+        self.assertRaises(Exc, baddict2.fromkeys, [1])
+
+    def test_copy(self):
+        d = self._full_mapping({1:1, 2:2, 3:3})
+        self.assertEqual(d.copy(), {1:1, 2:2, 3:3})
+        d = self._empty_mapping()
+        self.assertEqual(d.copy(), d)
+        self.assertIsInstance(d.copy(), d.__class__)
+        self.assertRaises(TypeError, d.copy, None)
+
+    def test_get(self):
+        BasicTestMappingProtocol.test_get(self)
+        d = self._empty_mapping()
+        self.assertTrue(d.get('c') is None)
+        self.assertEqual(d.get('c', 3), 3)
+        d = self._full_mapping({'a' : 1, 'b' : 2})
+        self.assertTrue(d.get('c') is None)
+        self.assertEqual(d.get('c', 3), 3)
+        self.assertEqual(d.get('a'), 1)
+        self.assertEqual(d.get('a', 3), 1)
+
+    def test_setdefault(self):
+        BasicTestMappingProtocol.test_setdefault(self)
+        d = self._empty_mapping()
+        self.assertTrue(d.setdefault('key0') is None)
+        d.setdefault('key0', [])
+        self.assertTrue(d.setdefault('key0') is None)
+        d.setdefault('key', []).append(3)
+        self.assertEqual(d['key'][0], 3)
+        d.setdefault('key', []).append(4)
+        self.assertEqual(len(d['key']), 2)
+
+    def test_popitem(self):
+        BasicTestMappingProtocol.test_popitem(self)
+        # for copymode in -1, +1:
+        for copymode in -1, 1:
+            # -1: b has same structure as a
+            # +1: b is a.copy()
+            for log2size in range(12):
+                size = 2**log2size
+                a = self._empty_mapping()
+                b = self._empty_mapping()
+                for i in range(size):
+                    a[repr(i)] = i
+                    if copymode < 0:
+                        b[repr(i)] = i
+                if copymode > 0:
+                    b = a.copy()
+                for i in range(size):
+                    ka, va = ta = a.popitem()
+                    self.assertEqual(va, int(ka))
+                    kb, vb = tb = b.popitem()
+                    self.assertEqual(vb, int(kb))
+                    self.assertTrue(not(copymode < 0 and ta != tb))
+                self.assertTrue(not a)
+                self.assertTrue(not b)
+
+    def test_pop(self):
+        BasicTestMappingProtocol.test_pop(self)
+
+        # Tests for pop with specified key
+        d = self._empty_mapping()
+        k, v = 'abc', 'def'
+
+        # verify longs/ints get same value when key > 32 bits (for 64-bit archs)
+        # see SF bug #689659
+        x = 4503599627370496L
+        y = 4503599627370496
+        h = self._full_mapping({x: 'anything', y: 'something else'})
+        self.assertEqual(h[x], h[y])
+
+        self.assertEqual(d.pop(k, v), v)
+        d[k] = v
+        self.assertEqual(d.pop(k, 1), v)
+
+
+class TestHashMappingProtocol(TestMappingProtocol):
+
+    def test_getitem(self):
+        TestMappingProtocol.test_getitem(self)
+        class Exc(Exception): pass
+
+        class BadEq(object):
+            def __eq__(self, other):
+                raise Exc()
+            def __hash__(self):
+                return 24
+
+        d = self._empty_mapping()
+        d[BadEq()] = 42
+        self.assertRaises(KeyError, d.__getitem__, 23)
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        d = self._empty_mapping()
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.__getitem__, x)
+
+    def test_fromkeys(self):
+        TestMappingProtocol.test_fromkeys(self)
+        class mydict(self.type2test):
+            def __new__(cls):
+                return UserDict.UserDict()
+        ud = mydict.fromkeys('ab')
+        self.assertEqual(ud, {'a':None, 'b':None})
+        self.assertIsInstance(ud, UserDict.UserDict)
+
+    def test_pop(self):
+        TestMappingProtocol.test_pop(self)
+
+        class Exc(Exception): pass
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        d = self._empty_mapping()
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.pop, x)
+
+    def test_mutatingiteration(self):
+        d = self._empty_mapping()
+        d[1] = 1
+        try:
+            for i in d:
+                d[i+1] = 1
+        except RuntimeError:
+            pass
+        else:
+            self.fail("changing dict size during iteration doesn't raise Error")
+
+    def test_repr(self):
+        d = self._empty_mapping()
+        self.assertEqual(repr(d), '{}')
+        d[1] = 2
+        self.assertEqual(repr(d), '{1: 2}')
+        d = self._empty_mapping()
+        d[1] = d
+        self.assertEqual(repr(d), '{1: {...}}')
+
+        class Exc(Exception): pass
+
+        class BadRepr(object):
+            def __repr__(self):
+                raise Exc()
+
+        d = self._full_mapping({1: BadRepr()})
+        self.assertRaises(Exc, repr, d)
+
+    def test_le(self):
+        self.assertTrue(not (self._empty_mapping() < self._empty_mapping()))
+        self.assertTrue(not (self._full_mapping({1: 2}) < self._full_mapping({1L: 2L})))
+
+        class Exc(Exception): pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                raise Exc()
+            def __hash__(self):
+                return 42
+
+        d1 = self._full_mapping({BadCmp(): 1})
+        d2 = self._full_mapping({1: 1})
+        try:
+            d1 < d2
+        except Exc:
+            pass
+        else:
+            self.fail("< didn't raise Exc")
+
+    def test_setdefault(self):
+        TestMappingProtocol.test_setdefault(self)
+
+        class Exc(Exception): pass
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        d = self._empty_mapping()
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.setdefault, x, [])

--- a/third_party/stdlib/test/test_dict.py
+++ b/third_party/stdlib/test/test_dict.py
@@ -1,0 +1,734 @@
+import unittest
+from test import test_support
+
+import UserDict, random, string
+# import gc, weakref
+
+
+class DictTest(unittest.TestCase):
+    def test_constructor(self):
+        # calling built-in types without argument must return empty
+        self.assertEqual(dict(), {})
+        self.assertIsNot(dict(), {})
+
+    @unittest.expectedFailure
+    def test_literal_constructor(self):
+        # check literal constructor for different sized dicts
+        # (to exercise the BUILD_MAP oparg).
+        for n in (0, 1, 6, 256, 400):
+            items = [(''.join(random.sample(string.letters, 8)), i)
+                     for i in range(n)]
+            random.shuffle(items)
+            formatted_items = ('{!r}: {:d}'.format(k, v) for k, v in items)
+            dictliteral = '{' + ', '.join(formatted_items) + '}'
+            self.assertEqual(eval(dictliteral), dict(items))
+
+    def test_bool(self):
+        self.assertIs(not {}, True)
+        self.assertTrue({1: 2})
+        self.assertIs(bool({}), False)
+        self.assertIs(bool({1: 2}), True)
+
+    @unittest.expectedFailure
+    def test_keys(self):
+        d = {}
+        self.assertEqual(d.keys(), [])
+        d = {'a': 1, 'b': 2}
+        k = d.keys()
+        # self.assertEqual(set(k), {'a', 'b'})
+        self.assertIn('a', k)
+        self.assertIn('b', k)
+        self.assertTrue(d.has_key('a'))
+        self.assertTrue(d.has_key('b'))
+        self.assertRaises(TypeError, d.keys, None)
+
+    @unittest.expectedFailure
+    def test_values(self):
+        d = {}
+        self.assertEqual(d.values(), [])
+        d = {1:2}
+        self.assertEqual(d.values(), [2])
+
+        self.assertRaises(TypeError, d.values, None)
+
+    def test_items(self):
+        d = {}
+        self.assertEqual(d.items(), [])
+
+        d = {1:2}
+        self.assertEqual(d.items(), [(1, 2)])
+
+        self.assertRaises(TypeError, d.items, None)
+
+    @unittest.expectedFailure
+    def test_has_key(self):
+        d = {}
+        self.assertFalse(d.has_key('a'))
+        d = {'a': 1, 'b': 2}
+        k = d.keys()
+        k.sort()
+        self.assertEqual(k, ['a', 'b'])
+
+        self.assertRaises(TypeError, d.has_key)
+
+    def test_contains(self):
+        d = {}
+        self.assertNotIn('a', d)
+        self.assertFalse('a' in d)
+        self.assertTrue('a' not in d)
+        d = {'a': 1, 'b': 2}
+        self.assertIn('a', d)
+        self.assertIn('b', d)
+        self.assertNotIn('c', d)
+
+        self.assertRaises(TypeError, d.__contains__)
+
+    def test_len(self):
+        d = {}
+        self.assertEqual(len(d), 0)
+        d = {'a': 1, 'b': 2}
+        self.assertEqual(len(d), 2)
+
+    def test_getitem(self):
+        d = {'a': 1, 'b': 2}
+        self.assertEqual(d['a'], 1)
+        self.assertEqual(d['b'], 2)
+        d['c'] = 3
+        d['a'] = 4
+        self.assertEqual(d['c'], 3)
+        self.assertEqual(d['a'], 4)
+        del d['b']
+        self.assertEqual(d, {'a': 4, 'c': 3})
+
+        self.assertRaises(TypeError, d.__getitem__)
+
+        class BadEq(object):
+            def __eq__(self, other):
+                raise Exc()
+            def __hash__(self):
+                return 24
+
+        d = {}
+        d[BadEq()] = 42
+        self.assertRaises(KeyError, d.__getitem__, 23)
+
+        class Exc(Exception): pass
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.__getitem__, x)
+
+    def test_clear(self):
+        d = {1:1, 2:2, 3:3}
+        d.clear()
+        self.assertEqual(d, {})
+
+        self.assertRaises(TypeError, d.clear, None)
+
+    @unittest.expectedFailure
+    def test_update(self):
+        d = {}
+        d.update({1:100})
+        d.update({2:20})
+        d.update({1:1, 2:2, 3:3})
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        d.update()
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        self.assertRaises((TypeError, AttributeError), d.update, None)
+
+        class SimpleUserDict(object):
+            def __init__(self):
+                self.d = {1:1, 2:2, 3:3}
+            def keys(self):
+                return self.d.keys()
+            def __getitem__(self, i):
+                return self.d[i]
+        d.clear()
+        d.update(SimpleUserDict())
+        self.assertEqual(d, {1:1, 2:2, 3:3})
+
+        class Exc(Exception): pass
+
+        d.clear()
+        class FailingUserDict(object):
+            def keys(self):
+                raise Exc
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        class FailingUserDict(object):
+            def keys(self):
+                class BogonIter(object):
+                    def __init__(self):
+                        self.i = 1
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i:
+                            self.i = 0
+                            return 'a'
+                        raise Exc
+                return BogonIter()
+            def __getitem__(self, key):
+                return key
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        class FailingUserDict(object):
+            def keys(self):
+                class BogonIter(object):
+                    def __init__(self):
+                        self.i = ord('a')
+                    def __iter__(self):
+                        return self
+                    def next(self):
+                        if self.i <= ord('z'):
+                            rtn = chr(self.i)
+                            self.i += 1
+                            return rtn
+                        raise StopIteration
+                return BogonIter()
+            def __getitem__(self, key):
+                raise Exc
+        self.assertRaises(Exc, d.update, FailingUserDict())
+
+        class badseq(object):
+            def __iter__(self):
+                return self
+            def next(self):
+                raise Exc()
+
+        self.assertRaises(Exc, {}.update, badseq())
+
+        self.assertRaises(ValueError, {}.update, [(1, 2, 3)])
+
+    @unittest.expectedFailure
+    def test_fromkeys(self):
+        self.assertEqual(dict.fromkeys('abc'), {'a':None, 'b':None, 'c':None})
+        d = {}
+        self.assertIsNot(d.fromkeys('abc'), d)
+        self.assertEqual(d.fromkeys('abc'), {'a':None, 'b':None, 'c':None})
+        self.assertEqual(d.fromkeys((4,5),0), {4:0, 5:0})
+        self.assertEqual(d.fromkeys([]), {})
+        def g():
+            yield 1
+        self.assertEqual(d.fromkeys(g()), {1:None})
+        self.assertRaises(TypeError, {}.fromkeys, 3)
+        class dictlike(dict): pass
+        self.assertEqual(dictlike.fromkeys('a'), {'a':None})
+        self.assertEqual(dictlike().fromkeys('a'), {'a':None})
+        self.assertIsInstance(dictlike.fromkeys('a'), dictlike)
+        self.assertIsInstance(dictlike().fromkeys('a'), dictlike)
+        class mydict(dict):
+            def __new__(cls):
+                return UserDict.UserDict()
+        ud = mydict.fromkeys('ab')
+        self.assertEqual(ud, {'a':None, 'b':None})
+        self.assertIsInstance(ud, UserDict.UserDict)
+        self.assertRaises(TypeError, dict.fromkeys)
+
+        class Exc(Exception): pass
+
+        class baddict1(dict):
+            def __init__(self):
+                raise Exc()
+
+        self.assertRaises(Exc, baddict1.fromkeys, [1])
+
+        class BadSeq(object):
+            def __iter__(self):
+                return self
+            def next(self):
+                raise Exc()
+
+        self.assertRaises(Exc, dict.fromkeys, BadSeq())
+
+        class baddict2(dict):
+            def __setitem__(self, key, value):
+                raise Exc()
+
+        self.assertRaises(Exc, baddict2.fromkeys, [1])
+
+        # test fast path for dictionary inputs
+        d = dict(zip(range(6), range(6)))
+        self.assertEqual(dict.fromkeys(d, 0), dict(zip(range(6), [0]*6)))
+
+        class baddict3(dict):
+            def __new__(cls):
+                return d
+        d = {i : i for i in range(10)}
+        res = d.copy()
+        res.update(a=None, b=None, c=None)
+        # self.assertEqual(baddict3.fromkeys({"a", "b", "c"}), res)
+
+    @unittest.expectedFailure
+    def test_copy(self):
+        d = {1:1, 2:2, 3:3}
+        self.assertEqual(d.copy(), {1:1, 2:2, 3:3})
+        self.assertEqual({}.copy(), {})
+        self.assertRaises(TypeError, d.copy, None)
+
+    def test_get(self):
+        d = {}
+        self.assertIs(d.get('c'), None)
+        self.assertEqual(d.get('c', 3), 3)
+        d = {'a': 1, 'b': 2}
+        self.assertIs(d.get('c'), None)
+        self.assertEqual(d.get('c', 3), 3)
+        self.assertEqual(d.get('a'), 1)
+        self.assertEqual(d.get('a', 3), 1)
+        self.assertRaises(TypeError, d.get)
+        self.assertRaises(TypeError, d.get, None, None, None)
+
+    @unittest.expectedFailure
+    def test_setdefault(self):
+        # dict.setdefault()
+        d = {}
+        self.assertIs(d.setdefault('key0'), None)
+        d.setdefault('key0', [])
+        self.assertIs(d.setdefault('key0'), None)
+        d.setdefault('key', []).append(3)
+        self.assertEqual(d['key'][0], 3)
+        d.setdefault('key', []).append(4)
+        self.assertEqual(len(d['key']), 2)
+        self.assertRaises(TypeError, d.setdefault)
+
+        class Exc(Exception): pass
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.setdefault, x, [])
+
+    @unittest.expectedFailure
+    def test_setdefault_atomic(self):
+        # Issue #13521: setdefault() calls __hash__ and __eq__ only once.
+        class Hashed(object):
+            def __init__(self):
+                self.hash_count = 0
+                self.eq_count = 0
+            def __hash__(self):
+                self.hash_count += 1
+                return 42
+            def __eq__(self, other):
+                self.eq_count += 1
+                return id(self) == id(other)
+        hashed1 = Hashed()
+        y = {hashed1: 5}
+        hashed2 = Hashed()
+        y.setdefault(hashed2, [])
+        self.assertEqual(hashed1.hash_count, 1)
+        self.assertEqual(hashed2.hash_count, 1)
+        self.assertEqual(hashed1.eq_count + hashed2.eq_count, 1)
+
+    @unittest.expectedFailure
+    def test_popitem(self):
+        # dict.popitem()
+        # for copymode in -1, +1:
+        for copymode in -1, 1:
+            # -1: b has same structure as a
+            # +1: b is a.copy()
+            for log2size in range(12):
+                size = 2**log2size
+                a = {}
+                b = {}
+                for i in range(size):
+                    a[repr(i)] = i
+                    if copymode < 0:
+                        b[repr(i)] = i
+                if copymode > 0:
+                    b = a.copy()
+                for i in range(size):
+                    ka, va = ta = a.popitem()
+                    self.assertEqual(va, int(ka))
+                    kb, vb = tb = b.popitem()
+                    self.assertEqual(vb, int(kb))
+                    self.assertFalse(copymode < 0 and ta != tb)
+                self.assertFalse(a)
+                self.assertFalse(b)
+
+        d = {}
+        self.assertRaises(KeyError, d.popitem)
+
+    @unittest.expectedFailure
+    def test_pop(self):
+        # Tests for pop with specified key
+        d = {}
+        k, v = 'abc', 'def'
+        d[k] = v
+        self.assertRaises(KeyError, d.pop, 'ghi')
+
+        self.assertEqual(d.pop(k), v)
+        self.assertEqual(len(d), 0)
+
+        self.assertRaises(KeyError, d.pop, k)
+
+        # verify longs/ints get same value when key > 32 bits
+        # (for 64-bit archs).  See SF bug #689659.
+        x = 4503599627370496L
+        y = 4503599627370496
+        h = {x: 'anything', y: 'something else'}
+        self.assertEqual(h[x], h[y])
+
+        self.assertEqual(d.pop(k, v), v)
+        d[k] = v
+        self.assertEqual(d.pop(k, 1), v)
+
+        self.assertRaises(TypeError, d.pop)
+
+        class Exc(Exception): pass
+
+        class BadHash(object):
+            fail = False
+            def __hash__(self):
+                if self.fail:
+                    raise Exc()
+                else:
+                    return 42
+
+        x = BadHash()
+        d[x] = 42
+        x.fail = True
+        self.assertRaises(Exc, d.pop, x)
+
+    def test_mutatingiteration(self):
+        # changing dict size during iteration
+        d = {}
+        d[1] = 1
+        with self.assertRaises(RuntimeError):
+            for i in d:
+                d[i+1] = 1
+
+    def test_repr(self):
+        d = {}
+        self.assertEqual(repr(d), '{}')
+        d[1] = 2
+        self.assertEqual(repr(d), '{1: 2}')
+        d = {}
+        d[1] = d
+        self.assertEqual(repr(d), '{1: {...}}')
+
+        class Exc(Exception): pass
+
+        class BadRepr(object):
+            def __repr__(self):
+                raise Exc()
+
+        d = {1: BadRepr()}
+        self.assertRaises(Exc, repr, d)
+
+    @unittest.expectedFailure
+    def test_le(self):
+        self.assertFalse({} < {})
+        self.assertFalse({1: 2} < {1L: 2L})
+
+        class Exc(Exception): pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                raise Exc()
+            def __hash__(self):
+                return 42
+
+        d1 = {BadCmp(): 1}
+        d2 = {1: 1}
+
+        with self.assertRaises(Exc):
+            d1 < d2
+
+    @unittest.expectedFailure
+    def test_missing(self):
+        # Make sure dict doesn't have a __missing__ method
+        self.assertFalse(hasattr(dict, "__missing__"))
+        self.assertFalse(hasattr({}, "__missing__"))
+        # Test several cases:
+        # (D) subclass defines __missing__ method returning a value
+        # (E) subclass defines __missing__ method raising RuntimeError
+        # (F) subclass sets __missing__ instance variable (no effect)
+        # (G) subclass doesn't define __missing__ at all
+        class D(dict):
+            def __missing__(self, key):
+                return 42
+        d = D({1: 2, 3: 4})
+        self.assertEqual(d[1], 2)
+        self.assertEqual(d[3], 4)
+        self.assertNotIn(2, d)
+        self.assertNotIn(2, d.keys())
+        self.assertEqual(d[2], 42)
+
+        class E(dict):
+            def __missing__(self, key):
+                raise RuntimeError(key)
+        e = E()
+        with self.assertRaises(RuntimeError) as c:
+            e[42]
+        self.assertEqual(c.exception.args, (42,))
+
+        class F(dict):
+            def __init__(self):
+                # An instance variable __missing__ should have no effect
+                self.__missing__ = lambda key: None
+        f = F()
+        with self.assertRaises(KeyError) as c:
+            f[42]
+        self.assertEqual(c.exception.args, (42,))
+
+        class G(dict):
+            pass
+        g = G()
+        with self.assertRaises(KeyError) as c:
+            g[42]
+        self.assertEqual(c.exception.args, (42,))
+
+    @unittest.expectedFailure
+    def test_tuple_keyerror(self):
+        # SF #1576657
+        d = {}
+        with self.assertRaises(KeyError) as c:
+            d[(1,)]
+        self.assertEqual(c.exception.args, ((1,),))
+
+    # def test_bad_key(self):
+    #     # Dictionary lookups should fail if __cmp__() raises an exception.
+    #     class CustomException(Exception):
+    #         pass
+
+    #     class BadDictKey(object):
+    #         def __hash__(self):
+    #             return hash(self.__class__)
+
+    #         def __cmp__(self, other):
+    #             if isinstance(other, self.__class__):
+    #                 raise CustomException
+    #             return other
+
+    #     d = {}
+    #     x1 = BadDictKey()
+    #     x2 = BadDictKey()
+    #     d[x1] = 1
+    #     for stmt in ['d[x2] = 2',
+    #                  'z = d[x2]',
+    #                  'x2 in d',
+    #                  'd.has_key(x2)',
+    #                  'd.get(x2)',
+    #                  'd.setdefault(x2, 42)',
+    #                  'd.pop(x2)',
+    #                  'd.update({x2: 2})']:
+    #         with self.assertRaises(CustomException):
+    #             exec stmt in locals()
+
+    def test_resize1(self):
+        # Dict resizing bug, found by Jack Jansen in 2.2 CVS development.
+        # This version got an assert failure in debug build, infinite loop in
+        # release build.  Unfortunately, provoking this kind of stuff requires
+        # a mix of inserts and deletes hitting exactly the right hash codes in
+        # exactly the right order, and I can't think of a randomized approach
+        # that would be *likely* to hit a failing case in reasonable time.
+
+        d = {}
+        for i in range(5):
+            d[i] = i
+        for i in range(5):
+            del d[i]
+        for i in range(5, 9):  # i==8 was the problem
+            d[i] = i
+
+    def test_resize2(self):
+        # Another dict resizing bug (SF bug #1456209).
+        # This caused Segmentation faults or Illegal instructions.
+
+        class X(object):
+            def __hash__(self):
+                return 5
+            def __eq__(self, other):
+                if resizing:
+                    d.clear()
+                return False
+        d = {}
+        resizing = False
+        d[X()] = 1
+        d[X()] = 2
+        d[X()] = 3
+        d[X()] = 4
+        d[X()] = 5
+        # now trigger a resize
+        resizing = True
+        d[9] = 6
+
+    def test_empty_presized_dict_in_freelist(self):
+        # Bug #3537: if an empty but presized dict with a size larger
+        # than 7 was in the freelist, it triggered an assertion failure
+        with self.assertRaises(ZeroDivisionError):
+            d = {'a': 1 // 0, 'b': None, 'c': None, 'd': None, 'e': None,
+                 'f': None, 'g': None, 'h': None}
+        d = {}
+
+    # def test_container_iterator(self):
+    #     # Bug #3680: tp_traverse was not implemented for dictiter objects
+    #     class C(object):
+    #         pass
+    #     iterators = (dict.iteritems, dict.itervalues, dict.iterkeys)
+    #     for i in iterators:
+    #         obj = C()
+    #         ref = weakref.ref(obj)
+    #         container = {obj: 1}
+    #         obj.x = i(container)
+    #         del obj, container
+    #         gc.collect()
+    #         self.assertIs(ref(), None, "Cycle was not collected")
+
+    # def _not_tracked(self, t):
+    #     # Nested containers can take several collections to untrack
+    #     gc.collect()
+    #     gc.collect()
+    #     self.assertFalse(gc.is_tracked(t), t)
+
+    # def _tracked(self, t):
+    #     self.assertTrue(gc.is_tracked(t), t)
+    #     gc.collect()
+    #     gc.collect()
+    #     self.assertTrue(gc.is_tracked(t), t)
+
+    @test_support.cpython_only
+    def test_track_literals(self):
+        # Test GC-optimization of dict literals
+        x, y, z, w = 1.5, "a", (1, None), []
+
+        self._not_tracked({})
+        self._not_tracked({x:(), y:x, z:1})
+        self._not_tracked({1: "a", "b": 2})
+        self._not_tracked({1: 2, (None, True, False, ()): int})
+        self._not_tracked({1: object()})
+
+        # Dicts with mutable elements are always tracked, even if those
+        # elements are not tracked right now.
+        self._tracked({1: []})
+        self._tracked({1: ([],)})
+        self._tracked({1: {}})
+        self._tracked({1: set()})
+
+    @test_support.cpython_only
+    def test_track_dynamic(self):
+        # Test GC-optimization of dynamically-created dicts
+        class MyObject(object):
+            pass
+        x, y, z, w, o = 1.5, "a", (1, object()), [], MyObject()
+
+        d = dict()
+        self._not_tracked(d)
+        d[1] = "a"
+        self._not_tracked(d)
+        d[y] = 2
+        self._not_tracked(d)
+        d[z] = 3
+        self._not_tracked(d)
+        self._not_tracked(d.copy())
+        d[4] = w
+        self._tracked(d)
+        self._tracked(d.copy())
+        d[4] = None
+        self._not_tracked(d)
+        self._not_tracked(d.copy())
+
+        # dd isn't tracked right now, but it may mutate and therefore d
+        # which contains it must be tracked.
+        d = dict()
+        dd = dict()
+        d[1] = dd
+        self._not_tracked(dd)
+        self._tracked(d)
+        dd[1] = d
+        self._tracked(dd)
+
+        d = dict.fromkeys([x, y, z])
+        self._not_tracked(d)
+        dd = dict()
+        dd.update(d)
+        self._not_tracked(dd)
+        d = dict.fromkeys([x, y, z, o])
+        self._tracked(d)
+        dd = dict()
+        dd.update(d)
+        self._tracked(dd)
+
+        d = dict(x=x, y=y, z=z)
+        self._not_tracked(d)
+        d = dict(x=x, y=y, z=z, w=w)
+        self._tracked(d)
+        d = dict()
+        d.update(x=x, y=y, z=z)
+        self._not_tracked(d)
+        d.update(w=w)
+        self._tracked(d)
+
+        d = dict([(x, y), (z, 1)])
+        self._not_tracked(d)
+        d = dict([(x, y), (z, w)])
+        self._tracked(d)
+        d = dict()
+        d.update([(x, y), (z, 1)])
+        self._not_tracked(d)
+        d.update([(x, y), (z, w)])
+        self._tracked(d)
+
+    @test_support.cpython_only
+    def test_track_subtypes(self):
+        # Dict subtypes are always tracked
+        class MyDict(dict):
+            pass
+        self._tracked(MyDict())
+
+
+    # def test_free_after_iterating(self):
+    #     test_support.check_free_after_iterating(self, iter, dict)
+    #     test_support.check_free_after_iterating(self, lambda d: d.iterkeys(), dict)
+    #     test_support.check_free_after_iterating(self, lambda d: d.itervalues(), dict)
+    #     test_support.check_free_after_iterating(self, lambda d: d.iteritems(), dict)
+    #     test_support.check_free_after_iterating(self, lambda d: iter(d.viewkeys()), dict)
+    #     test_support.check_free_after_iterating(self, lambda d: iter(d.viewvalues()), dict)
+    #     test_support.check_free_after_iterating(self, lambda d: iter(d.viewitems()), dict)
+
+from test import mapping_tests
+
+class GeneralMappingTests(mapping_tests.BasicTestMappingProtocol):
+    type2test = dict
+
+class Dict(dict):
+    pass
+
+class SubclassMappingTests(mapping_tests.BasicTestMappingProtocol):
+    type2test = Dict
+
+def test_main():
+    with test_support.check_py3k_warnings(
+        ('dict(.has_key..| inequality comparisons) not supported in 3.x',
+         DeprecationWarning)):
+        test_support.run_unittest(
+            DictTest,
+            GeneralMappingTests,
+            SubclassMappingTests,
+        )
+
+if __name__ == "__main__":
+    import traceback
+    try:
+        test_main()
+    except:
+        traceback.print_exc()

--- a/third_party/stdlib/test/test_support.py
+++ b/third_party/stdlib/test/test_support.py
@@ -3,7 +3,7 @@
 # if __name__ != 'test.test_support':
 #     raise ImportError('test_support must be imported from the test package')
 
-# import contextlib
+import contextlib
 # import errno
 # import functools
 # import gc
@@ -12,7 +12,7 @@ import sys
 # import os
 # import platform
 # import shutil
-# import warnings
+import warnings
 import unittest
 # import importlib
 # import UserDict
@@ -25,7 +25,10 @@ import unittest
 # except ImportError:
 #     thread = None
 
-__all__ = ["Error", "TestFailed", "have_unicode", "BasicTestRunner", "run_unittest"]
+__all__ = [
+    "Error", "TestFailed", "have_unicode", "BasicTestRunner", "run_unittest",
+    "check_warnings", "check_py3k_warnings"
+]
 
 # __all__ = ["Error", "TestFailed", "ResourceDenied", "import_module",
 #            "verbose", "use_resources", "max_memuse", "record_original_stdout",
@@ -815,113 +818,113 @@ except NameError:
 #     raise TestFailed('invalid resource "%s"' % fn)
 
 
-# class WarningsRecorder(object):
-#     """Convenience wrapper for the warnings list returned on
-#        entry to the warnings.catch_warnings() context manager.
-#     """
-#     def __init__(self, warnings_list):
-#         self._warnings = warnings_list
-#         self._last = 0
+class WarningsRecorder(object):
+    """Convenience wrapper for the warnings list returned on
+       entry to the warnings.catch_warnings() context manager.
+    """
+    def __init__(self, warnings_list):
+        self._warnings = warnings_list
+        self._last = 0
 
-#     def __getattr__(self, attr):
-#         if len(self._warnings) > self._last:
-#             return getattr(self._warnings[-1], attr)
-#         elif attr in warnings.WarningMessage._WARNING_DETAILS:
-#             return None
-#         raise AttributeError("%r has no attribute %r" % (self, attr))
+    def __getattr__(self, attr):
+        if len(self._warnings) > self._last:
+            return getattr(self._warnings[-1], attr)
+        elif attr in warnings.WarningMessage._WARNING_DETAILS:
+            return None
+        raise AttributeError("%r has no attribute %r" % (self, attr))
 
-#     @property
-#     def warnings(self):
-#         return self._warnings[self._last:]
+    @property
+    def warnings(self):
+        return self._warnings[self._last:]
 
-#     def reset(self):
-#         self._last = len(self._warnings)
-
-
-# def _filterwarnings(filters, quiet=False):
-#     """Catch the warnings, then check if all the expected
-#     warnings have been raised and re-raise unexpected warnings.
-#     If 'quiet' is True, only re-raise the unexpected warnings.
-#     """
-#     # Clear the warning registry of the calling module
-#     # in order to re-raise the warnings.
-#     frame = sys._getframe(2)
-#     registry = frame.f_globals.get('__warningregistry__')
-#     if registry:
-#         registry.clear()
-#     with warnings.catch_warnings(record=True) as w:
-#         # Set filter "always" to record all warnings.  Because
-#         # test_warnings swap the module, we need to look up in
-#         # the sys.modules dictionary.
-#         sys.modules['warnings'].simplefilter("always")
-#         yield WarningsRecorder(w)
-#     # Filter the recorded warnings
-#     reraise = [warning.message for warning in w]
-#     missing = []
-#     for msg, cat in filters:
-#         seen = False
-#         for exc in reraise[:]:
-#             message = str(exc)
-#             # Filter out the matching messages
-#             if (re.match(msg, message, re.I) and
-#                 issubclass(exc.__class__, cat)):
-#                 seen = True
-#                 reraise.remove(exc)
-#         if not seen and not quiet:
-#             # This filter caught nothing
-#             missing.append((msg, cat.__name__))
-#     if reraise:
-#         raise AssertionError("unhandled warning %r" % reraise[0])
-#     if missing:
-#         raise AssertionError("filter (%r, %s) did not catch any warning" %
-#                              missing[0])
+    def reset(self):
+        self._last = len(self._warnings)
 
 
-# @contextlib.contextmanager
-# def check_warnings(*filters, **kwargs):
-#     """Context manager to silence warnings.
+def _filterwarnings(filters, quiet=False):
+    """Catch the warnings, then check if all the expected
+    warnings have been raised and re-raise unexpected warnings.
+    If 'quiet' is True, only re-raise the unexpected warnings.
+    """
+    # Clear the warning registry of the calling module
+    # in order to re-raise the warnings.
+    # frame = sys._getframe(2)
+    # registry = frame.f_globals.get('__warningregistry__')
+    # if registry:
+    #     registry.clear()
+    with warnings.catch_warnings(record=True) as w:
+        # Set filter "always" to record all warnings.  Because
+        # test_warnings swap the module, we need to look up in
+        # the sys.modules dictionary.
+        sys.modules['warnings'].simplefilter("always")
+        yield WarningsRecorder(w)
+    # Filter the recorded warnings
+    reraise = [warning.message for warning in w]
+    missing = []
+    for msg, cat in filters:
+        seen = False
+        for exc in reraise[:]:
+            message = str(exc)
+            # Filter out the matching messages
+            if (re.match(msg, message, re.I) and
+                issubclass(exc.__class__, cat)):
+                seen = True
+                reraise.remove(exc)
+        if not seen and not quiet:
+            # This filter caught nothing
+            missing.append((msg, cat.__name__))
+    if reraise:
+        raise AssertionError("unhandled warning %r" % reraise[0])
+    if missing:
+        raise AssertionError("filter (%r, %s) did not catch any warning" %
+                             missing[0])
 
-#     Accept 2-tuples as positional arguments:
-#         ("message regexp", WarningCategory)
 
-#     Optional argument:
-#      - if 'quiet' is True, it does not fail if a filter catches nothing
-#         (default True without argument,
-#          default False if some filters are defined)
+@contextlib.contextmanager
+def check_warnings(*filters, **kwargs):
+    """Context manager to silence warnings.
 
-#     Without argument, it defaults to:
-#         check_warnings(("", Warning), quiet=True)
-#     """
-#     quiet = kwargs.get('quiet')
-#     if not filters:
-#         filters = (("", Warning),)
-#         # Preserve backward compatibility
-#         if quiet is None:
-#             quiet = True
-#     return _filterwarnings(filters, quiet)
+    Accept 2-tuples as positional arguments:
+        ("message regexp", WarningCategory)
+
+    Optional argument:
+     - if 'quiet' is True, it does not fail if a filter catches nothing
+        (default True without argument,
+         default False if some filters are defined)
+
+    Without argument, it defaults to:
+        check_warnings(("", Warning), quiet=True)
+    """
+    quiet = kwargs.get('quiet')
+    if not filters:
+        filters = (("", Warning),)
+        # Preserve backward compatibility
+        if quiet is None:
+            quiet = True
+    return _filterwarnings(filters, quiet)
 
 
-# @contextlib.contextmanager
-# def check_py3k_warnings(*filters, **kwargs):
-#     """Context manager to silence py3k warnings.
+@contextlib.contextmanager
+def check_py3k_warnings(*filters, **kwargs):
+    """Context manager to silence py3k warnings.
 
-#     Accept 2-tuples as positional arguments:
-#         ("message regexp", WarningCategory)
+    Accept 2-tuples as positional arguments:
+        ("message regexp", WarningCategory)
 
-#     Optional argument:
-#      - if 'quiet' is True, it does not fail if a filter catches nothing
-#         (default False)
+    Optional argument:
+     - if 'quiet' is True, it does not fail if a filter catches nothing
+        (default False)
 
-#     Without argument, it defaults to:
-#         check_py3k_warnings(("", DeprecationWarning), quiet=False)
-#     """
-#     if sys.py3kwarning:
-#         if not filters:
-#             filters = (("", DeprecationWarning),)
-#     else:
-#         # It should not raise any py3k warning
-#         filters = ()
-#     return _filterwarnings(filters, kwargs.get('quiet'))
+    Without argument, it defaults to:
+        check_py3k_warnings(("", DeprecationWarning), quiet=False)
+    """
+    if sys.py3kwarning:
+        if not filters:
+            filters = (("", DeprecationWarning),)
+    else:
+        # It should not raise any py3k warning
+        filters = ()
+    return _filterwarnings(filters, kwargs.get('quiet'))
 
 
 # class CleanImport(object):
@@ -1386,7 +1389,7 @@ def _id(obj):
 #         return unittest.skip("resource {0!r} is not enabled".format(resource))
 
 def cpython_only(test):
-    return lambda: None
+    return lambda *arg, **kw: None
 
 # def cpython_only(test):
 #     """


### PR DESCRIPTION
- This required decorators, need to rebase once decorators are ok.
- Currently unsupported tests are marked as expectedFailure.
- Minor changes on unittest and contextlib to make this work with least modifications.
- Haven't included this test in Makefile yet.

```
test_bool (__main__.DictTest) ... ok
test_clear (__main__.DictTest) ... ok
test_constructor (__main__.DictTest) ... ok
test_contains (__main__.DictTest) ... ok
test_copy (__main__.DictTest) ... expected failure
test_empty_presized_dict_in_freelist (__main__.DictTest) ... ok
test_fromkeys (__main__.DictTest) ... expected failure
test_get (__main__.DictTest) ... ok
test_getitem (__main__.DictTest) ... ok
test_has_key (__main__.DictTest) ... expected failure
test_items (__main__.DictTest) ... ok
test_keys (__main__.DictTest) ... expected failure
test_le (__main__.DictTest) ... expected failure
test_len (__main__.DictTest) ... ok
test_literal_constructor (__main__.DictTest) ... expected failure
test_missing (__main__.DictTest) ... expected failure
test_mutatingiteration (__main__.DictTest) ... ok
test_pop (__main__.DictTest) ... expected failure
test_popitem (__main__.DictTest) ... expected failure
test_repr (__main__.DictTest) ... ok
test_resize1 (__main__.DictTest) ... ok
test_resize2 (__main__.DictTest) ... ok
test_setdefault (__main__.DictTest) ... expected failure
test_setdefault_atomic (__main__.DictTest) ... expected failure
test_track_dynamic (__main__.DictTest) ... ok
test_track_literals (__main__.DictTest) ... ok
test_track_subtypes (__main__.DictTest) ... ok
test_tuple_keyerror (__main__.DictTest) ... expected failure
test_update (__main__.DictTest) ... expected failure
test_values (__main__.DictTest) ... expected failure

----------------------------------------------------------------------
Ran 30 tests in 0.011339s

OK (expected failures=14)
```
