### PR TITLE
Cache frames for fast reuse.

### DIFF
--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -337,6 +337,7 @@ func builtinFrame(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "__frame__", args); raised != nil {
 		return nil, raised
 	}
+	f.taken = true
 	return f.ToObject(), nil
 }
 

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -339,7 +339,7 @@ func captureStdout(f *Frame, fn func() *BaseException) (string, *BaseException) 
 func TestBuiltinPrint(t *testing.T) {
 	fun := wrapFuncForTest(func(f *Frame, args *Tuple, kwargs KWArgs) (string, *BaseException) {
 		return captureStdout(f, func() *BaseException {
-			_, raised := builtinPrint(newFrame(nil), args.elems, kwargs)
+			_, raised := builtinPrint(NewRootFrame(), args.elems, kwargs)
 			return raised
 		})
 	})

--- a/runtime/code.go
+++ b/runtime/code.go
@@ -134,10 +134,11 @@ func (c *Code) Eval(f *Frame, globals *Dict, args Args, kwargs KWArgs) (*Object,
 		}
 	}
 	oldExc, oldTraceback := f.ExcInfo()
-	next := newFrame(f)
+	next := newChildFrame(f)
 	next.code = c
 	next.globals = globals
 	ret, raised := c.fn(next, bodyArgs)
+	next.release()
 	f.FreeArgs(bodyArgs)
 	if raised == nil {
 		// Restore exc_info to what it was when we left the previous

--- a/runtime/frame_test.go
+++ b/runtime/frame_test.go
@@ -174,12 +174,12 @@ func TestFrameRaiseType(t *testing.T) {
 func TestReprEnterLeave(t *testing.T) {
 	o := newObject(ObjectType)
 	parent := NewRootFrame()
-	child := newFrame(parent)
+	child := newChildFrame(parent)
 	wantParent := NewRootFrame()
 	wantParent.reprState = map[*Object]bool{o: true}
 	child.reprEnter(o)
 	// After child.reprEnter(), expect the parent's reprState to contain o.
-	if wantChild := newFrame(parent); !reflect.DeepEqual(child, wantChild) {
+	if wantChild := newChildFrame(parent); !reflect.DeepEqual(child, wantChild) {
 		t.Errorf("reprEnter: child frame was %#v, want %#v", child, wantChild)
 	} else if !reflect.DeepEqual(parent, wantParent) {
 		t.Errorf("reprEnter: parent frame was %#v, want %#v", parent, wantParent)
@@ -187,7 +187,7 @@ func TestReprEnterLeave(t *testing.T) {
 		wantParent.reprState = map[*Object]bool{}
 		child.reprLeave(o)
 		// Expect the parent's reprState to be empty after reprLeave().
-		if wantChild := newFrame(parent); !reflect.DeepEqual(child, wantChild) {
+		if wantChild := newChildFrame(parent); !reflect.DeepEqual(child, wantChild) {
 			t.Errorf("reprLeave: child frame was %#v, want %#v", child, wantChild)
 		} else if !reflect.DeepEqual(parent, wantParent) {
 			t.Errorf("reprLeave: parent frame was %#v, want %#v", parent, wantParent)
@@ -197,8 +197,8 @@ func TestReprEnterLeave(t *testing.T) {
 
 func TestFrameRoot(t *testing.T) {
 	f1 := NewRootFrame()
-	f2 := newFrame(f1)
-	frames := []*Frame{f1, f2, newFrame(f2)}
+	f2 := newChildFrame(f1)
+	frames := []*Frame{f1, f2, newChildFrame(f2)}
 	for _, f := range frames {
 		if f.threadState != f1.threadState {
 			t.Errorf("frame threadState was %v, want %v", f.threadState, f1.threadState)

--- a/runtime/generator.go
+++ b/runtime/generator.go
@@ -44,6 +44,12 @@ type Generator struct {
 
 // NewGenerator returns a new Generator object that runs the given Block b.
 func NewGenerator(f *Frame, fn func(*Object) (*Object, *BaseException)) *Generator {
+	f.taken = true // Claim the frame from being returned.
+
+	// The code generator basically gives us the Frame, so we can tare it
+	// off and prevent a parasitic `taken` from creeping up the frames.
+	f.back = nil
+
 	return &Generator{Object: Object{typ: GeneratorType}, frame: f, fn: fn}
 }
 

--- a/runtime/native_test.go
+++ b/runtime/native_test.go
@@ -470,7 +470,7 @@ func TestNativeTypeName(t *testing.T) {
 }
 
 func TestNewNativeFieldChecksInstanceType(t *testing.T) {
-	f := newFrame(nil)
+	f := NewRootFrame()
 
 	// Given a native object
 	native, raised := WrapNative(f, reflect.ValueOf(struct{ foo string }{}))

--- a/runtime/threading.go
+++ b/runtime/threading.go
@@ -35,6 +35,11 @@ type threadState struct {
 	// is full are dropped. If the cache is empty then a new args slice
 	// will be allocated.
 	argsCache []Args
+
+	// frameCache is a local cache of allocated frames almost ready for
+	// reuse. The cache is maintained through the Frame `back` pointer as a
+	// singly linked list.
+	frameCache *Frame
 }
 
 func newThreadState() *threadState {

--- a/runtime/traceback.go
+++ b/runtime/traceback.go
@@ -27,6 +27,7 @@ type Traceback struct {
 }
 
 func newTraceback(f *Frame, next *Traceback) *Traceback {
+	f.taken = true
 	return &Traceback{Object{typ: TracebackType}, f, next, f.lineno}
 }
 


### PR DESCRIPTION
Rather than allocating a frame on every call, we keep an already allocated list of frames ready to go. This trades lightly more memory usage for faster calls.

This can have a dramatic improvement. On `bm_call_simple` the execution time goes from ~851ms to ~281ms for almost a 67% reduction (CPython is ~10ms - yes ten). Other benchmarks are similarly improved when they make a number of calls:

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkCallSimple                851509025     281303472     -66.96%
BenchmarkCallDefaults              259           118           -54.44%
BenchmarkCallKeywords              461           302           -34.49%
BenchmarkCallKwargs                1449          1252          -13.60%
BenchmarkCallNoArgs                254           105           -58.66%
BenchmarkCallPositionalArgs        284           121           -57.39%
BenchmarkCallVarArgs               497           341           -31.39%
BenchmarkDictCompCreate            479559        466262        -2.77%
BenchmarkGeneratorExpCreate        1335          1324          -0.82%
BenchmarkGeneratorExpIterate       128           132           +3.12%
BenchmarkListCompCreate            133363        132768        -0.45%
BenchmarkArithmetic                1010          916           -9.31%
BenchmarkArithmeticParallel10      1057          1001          -5.30%
BenchmarkArithmeticParallel11      1034          989           -4.35%
BenchmarkArithmeticParallel12      1083          1002          -7.48%
BenchmarkArithmeticParallel2       1047          1006          -3.92%
BenchmarkArithmeticParallel3       1058          1019          -3.69%
BenchmarkArithmeticParallel5       1051          1006          -4.28%
BenchmarkArithmeticParallel6       1063          976           -8.18%
BenchmarkArithmeticParallel7       1065          993           -6.76%
BenchmarkArithmeticParallel8       1052          995           -5.42%
BenchmarkArithmeticParallel9       1070          1003          -6.26%
BenchmarkFib                       15733         5572          -64.58%
BenchmarkFibParallel10             18298         5512          -69.88%
BenchmarkFibParallel11             19196         5458          -71.57%
BenchmarkFibParallel12             19903         5604          -71.84%
BenchmarkFibParallel2              15884         5433          -65.80%
BenchmarkFibParallel3              16013         5402          -66.26%
BenchmarkFibParallel4              16348         5447          -66.68%
BenchmarkFibParallel5              17124         5454          -68.15%
BenchmarkFibParallel6              16710         5425          -67.53%
BenchmarkFibParallel7              17466         5432          -68.90%
BenchmarkFibParallel8              17853         5534          -69.00%
BenchmarkFibParallel9              18187         5460          -69.98%
BenchmarkDictGetItem               137           131           -4.38%
BenchmarkDictStringOnlyGetItem     138           134           -2.90%
BenchmarkDictStringOnlySetItem     274           266           -2.92%
BenchmarkHashStrCached             118           114           -3.39%
BenchmarkGeneratorCreate           466           508           +9.01%
BenchmarkListContains10            1000          1007          +0.70%
BenchmarkListContains3             488           484           -0.82%
BenchmarkListGetItem               109           110           +0.92%
BenchmarkForXRange                 74.4          78.2          +5.11%
BenchmarkWhileCounter              486           489           +0.62%
BenchmarkWhileXRange               428           445           +3.97%
BenchmarkTupleContains10           2448          2415          -1.35%
BenchmarkTupleContains3            1030          1058          +2.72%
BenchmarkTupleGetItem              101           100           -0.99%

benchmark                         old allocs     new allocs     delta
BenchmarkCallSimple               3368434        6              -100.00%
BenchmarkCallDefaults             1              0              -100.00%
BenchmarkCallKeywords             2              1              -50.00%
BenchmarkCallKwargs               8              7              -12.50%
BenchmarkCallNoArgs               1              0              -100.00%
BenchmarkCallPositionalArgs       1              0              -100.00%
BenchmarkCallVarArgs              3              2              -33.33%
BenchmarkArithmetic               10             9              -10.00%
BenchmarkArithmeticParallel10     10             9              -10.00%
BenchmarkArithmeticParallel11     10             9              -10.00%
BenchmarkArithmeticParallel12     10             9              -10.00%
BenchmarkArithmeticParallel2      10             9              -10.00%
BenchmarkArithmeticParallel3      10             9              -10.00%
BenchmarkArithmeticParallel4      10             9              -10.00%
BenchmarkArithmeticParallel5      10             9              -10.00%
BenchmarkArithmeticParallel6      10             9              -10.00%
BenchmarkArithmeticParallel7      10             9              -10.00%
BenchmarkArithmeticParallel8      10             9              -10.00%
BenchmarkArithmeticParallel9      10             9              -10.00%
BenchmarkFib                      187            10             -94.65%
BenchmarkFibParallel10            187            10             -94.65%
BenchmarkFibParallel11            187            10             -94.65%
BenchmarkFibParallel12            187            10             -94.65%
BenchmarkFibParallel2             187            10             -94.65%
BenchmarkFibParallel3             187            10             -94.65%
BenchmarkFibParallel4             187            10             -94.65%
BenchmarkFibParallel5             187            10             -94.65%
BenchmarkFibParallel6             187            10             -94.65%
BenchmarkFibParallel7             187            10             -94.65%
BenchmarkFibParallel8             187            10             -94.65%
BenchmarkFibParallel9             187            10             -94.65%

benchmark                         old bytes     new bytes     delta
BenchmarkCallSimple               323369256     432           -100.00%
BenchmarkCallDefaults             127           31            -75.59%
BenchmarkCallKeywords             207           111           -46.38%
BenchmarkCallKwargs               479           383           -20.04%
BenchmarkCallNoArgs               127           31            -75.59%
BenchmarkCallPositionalArgs       127           31            -75.59%
BenchmarkCallVarArgs              207           111           -46.38%
BenchmarkDictCompCreate           142045        142061        +0.01%
BenchmarkGeneratorExpCreate       655           671           +2.44%
BenchmarkListCompCreate           40367         40383         +0.04%
BenchmarkArithmetic               352           256           -27.27%
BenchmarkArithmeticParallel10     352           256           -27.27%
BenchmarkArithmeticParallel11     352           256           -27.27%
BenchmarkArithmeticParallel12     352           256           -27.27%
BenchmarkArithmeticParallel2      352           256           -27.27%
BenchmarkArithmeticParallel3      352           256           -27.27%
BenchmarkArithmeticParallel4      352           256           -27.27%
BenchmarkArithmeticParallel5      352           256           -27.27%
BenchmarkArithmeticParallel6      352           256           -27.27%
BenchmarkArithmeticParallel7      352           256           -27.27%
BenchmarkArithmeticParallel8      352           256           -27.27%
BenchmarkArithmeticParallel9      352           256           -27.27%
BenchmarkFib                      17328         336           -98.06%
BenchmarkFibParallel10            17330         337           -98.06%
BenchmarkFibParallel11            17331         337           -98.06%
BenchmarkFibParallel12            17331         337           -98.06%
BenchmarkFibParallel2             17328         336           -98.06%
BenchmarkFibParallel3             17328         336           -98.06%
BenchmarkFibParallel4             17329         336           -98.06%
BenchmarkFibParallel5             17329         336           -98.06%
BenchmarkFibParallel6             17329         336           -98.06%
BenchmarkFibParallel7             17329         336           -98.06%
BenchmarkFibParallel8             17330         336           -98.06%
BenchmarkFibParallel9             17330         337           -98.06%
BenchmarkGeneratorCreate          231           247           +6.93%
```