### PR TITLE
Add bm_call_method and bm_call_simple from the python benchmark suite.

### DIFF
--- a/benchmarks/bm_call_method.py
+++ b/benchmarks/bm_call_method.py
@@ -1,0 +1,138 @@
+"""Microbenchmark for method call overhead.
+
+This measures simple method calls that are predictable, do not use varargs or
+kwargs, and do not use tuple unpacking.
+
+Taken from:
+https://github.com/python/performance/blob/9b8d859/performance/benchmarks/bm_call_method.py
+"""
+
+import weetest
+
+
+class Foo(object):
+
+  def foo(self, a, b, c, d):
+    # 20 calls
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+    self.bar(a, b, c)
+
+  def bar(self, a, b, c):
+    # 20 calls
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+    self.baz(a, b)
+
+  def baz(self, a, b):
+    # 20 calls
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+    self.quux(a)
+
+  def quux(self, a):
+    # 20 calls
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+    self.qux()
+
+  def qux(self):
+    pass
+
+
+def BenchmarkCallMethod(b):
+  f = Foo()
+  for _ in xrange(b.N):
+    # 20 calls
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+    f.foo(1, 2, 3, 4)
+
+
+if __name__ == '__main__':
+  weetest.RunBenchmarks()

--- a/benchmarks/bm_call_simple.py
+++ b/benchmarks/bm_call_simple.py
@@ -1,0 +1,139 @@
+"""Microbenchmark for function call overhead.
+
+This measures simple function calls that are not methods, do not use varargs or
+kwargs, and do not use tuple unpacking.
+
+Taken from:
+https://github.com/python/performance/blob/9b8d859/performance/benchmarks/bm_call_simple.py
+"""
+
+import weetest
+
+
+def foo(a, b, c, d):
+  # 20 calls
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+  bar(a, b, c)
+
+
+def bar(a, b, c):
+  # 20 calls
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+  baz(a, b)
+
+
+def baz(a, b):
+  # 20 calls
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+  quux(a)
+
+
+def quux(a):
+  # 20 calls
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+  qux()
+
+
+def qux():
+  pass
+
+
+def BenchmarkCallSimple(b):
+  for _ in xrange(b.N):
+    # 20 calls
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+    foo(1, 2, 3, 4)
+
+
+if __name__ == '__main__':
+  weetest.RunBenchmarks()


### PR DESCRIPTION
Minimal change were made - mostly a change from using the perf module to using weetest. This helps a little with gauging where grumpy is when compared to CPython.