### PR TITLE
Allow passing Python functions to Go for invocation.

### DIFF
--- a/runtime/function.go
+++ b/runtime/function.go
@@ -134,6 +134,10 @@ func functionGet(_ *Frame, desc, instance *Object, owner *Type) (*Object, *BaseE
 	return NewMethod(toFunctionUnsafe(desc), instance, owner).ToObject(), nil
 }
 
+func functionNative(f *Frame, o *Object) (reflect.Value, *BaseException) {
+	return reflect.ValueOf(o.Call), nil
+}
+
 func functionRepr(_ *Frame, o *Object) (*Object, *BaseException) {
 	fun := toFunctionUnsafe(o)
 	return NewStr(fmt.Sprintf("<%s %s at %p>", fun.typ.Name(), fun.Name(), fun)).ToObject(), nil
@@ -143,6 +147,7 @@ func initFunctionType(map[string]*Object) {
 	FunctionType.flags &= ^(typeFlagInstantiable | typeFlagBasetype)
 	FunctionType.slots.Call = &callSlot{functionCall}
 	FunctionType.slots.Get = &getSlot{functionGet}
+	FunctionType.slots.Native = &nativeSlot{functionNative}
 	FunctionType.slots.Repr = &unaryOpSlot{functionRepr}
 }
 


### PR DESCRIPTION
Big WIP - This code is gnarly and rather than continuing to sit on it, thoughts on how to handle all the nasty `panics` below? There has to be better ways. Regardless, this opens up a lot more interoperability with the Go ecosystem - just a matter of how to handle error cases.