### PR TITLE
[WIP] Implement members / wildcard imports

### DIFF
--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -362,15 +362,6 @@ class StatementVisitorTest(unittest.TestCase):
       self.assertRaisesRegexp(util.ParseError, want_regexp,
                               stmt.import_from_future, node)
 
-  def testImportWildcardMemberRaises(self):
-    regexp = r'wildcard member import is not implemented: from foo import *'
-    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
-                            'from foo import *')
-    regexp = (r'wildcard member import is not '
-              r'implemented: from __go__.foo import *')
-    self.assertRaisesRegexp(util.ParseError, regexp, _ParseAndVisit,
-                            'from __go__.foo import *')
-
   def testVisitFuture(self):
     testcases = [
         ('from __future__ import print_function',


### PR DESCRIPTION
- I think this is more like a PoC, by trying to `__import__` module_name, if it does not work assume member imports, which means modules must be available at compile time.
- Wildcard imports only work for pure python modules, without `from __go__` statements on any of the dependencies. 
- Wildcard imports only look in $PWD/third_party/stdlib, $PWD/third_party/pypy, which is hard-coded, need to find better way, also using getcwd() does not look right.

```
% make run 
import os
import os.path
from os import path
from os import chdir
from os import path, chdir
from os import path as os_path, chdir as cd
from os.path import abspath, join as j
from test import test_support, seq_tests
from test import test_support
from test import test_support as support
import test.test_support
from test import mapping_tests

from sre_constants import ANY, BRANCH
from StringIO import *

print globals().keys()

^D
['test_support', 'chdir', 'StringIO', 'support', '__file__', 'j', 'cd', 'mapping_tests', 'sre_constants', 'ANY', 'seq_tests', 'BRANCH', 'path', 'test', '__name__', 'os_path', 'os', 'abspath', 'os.path']
```

If approach is acceptable I could continue to add tests and chore a bit more.
