### PR TITLE
Add stdlib list, slice tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,10 @@ STDLIB_TESTS := \
   re_tests \
   sys_test \
   tempfile_test \
-  test/seq_tests \
   test/test_tuple \
-  test/mapping_tests \
   test/test_dict \
-  test/string_tests \
+  test/test_list \
+  test/test_slice \
   test/test_string \
   threading_test \
   time_test \

--- a/third_party/stdlib/test/list_tests.py
+++ b/third_party/stdlib/test/list_tests.py
@@ -1,0 +1,545 @@
+"""
+Tests common to list and UserList.UserList
+"""
+
+import sys
+import os
+
+from test import test_support, seq_tests
+
+class CommonTest(seq_tests.CommonTest):
+
+    def test_init(self):
+        # Iterable arg is optional
+        self.assertEqual(self.type2test([]), self.type2test())
+
+        # Init clears previous values
+        a = self.type2test([1, 2, 3])
+        a.__init__()
+        self.assertEqual(a, self.type2test([]))
+
+        # Init overwrites previous values
+        a = self.type2test([1, 2, 3])
+        a.__init__([4, 5, 6])
+        self.assertEqual(a, self.type2test([4, 5, 6]))
+
+        # Mutables always return a new object
+        b = self.type2test(a)
+        self.assertNotEqual(id(a), id(b))
+        self.assertEqual(a, b)
+
+    def test_repr(self):
+        l0 = []
+        l2 = [0, 1, 2]
+        a0 = self.type2test(l0)
+        a2 = self.type2test(l2)
+
+        self.assertEqual(str(a0), str(l0))
+        self.assertEqual(repr(a0), repr(l0))
+        self.assertEqual(repr(a2), repr(l2))
+        self.assertEqual(str(a2), "[0, 1, 2]")
+        self.assertEqual(repr(a2), "[0, 1, 2]")
+
+        a2.append(a2)
+        a2.append(3)
+        self.assertEqual(str(a2), "[0, 1, 2, [...], 3]")
+        self.assertEqual(repr(a2), "[0, 1, 2, [...], 3]")
+
+        l0 = []
+        for i in xrange(sys.getrecursionlimit() + 100):
+            l0 = [l0]
+        self.assertRaises(RuntimeError, repr, l0)
+
+    def test_print(self):
+        d = self.type2test(xrange(200))
+        d.append(d)
+        d.extend(xrange(200,400))
+        d.append(d)
+        d.append(400)
+        try:
+            with open(test_support.TESTFN, "wb") as fo:
+                print >> fo, d,
+            with open(test_support.TESTFN, "rb") as fo:
+                self.assertEqual(fo.read(), repr(d))
+        finally:
+            os.remove(test_support.TESTFN)
+
+    def test_set_subscript(self):
+        a = self.type2test(range(20))
+        self.assertRaises(ValueError, a.__setitem__, slice(0, 10, 0), [1,2,3])
+        self.assertRaises(TypeError, a.__setitem__, slice(0, 10), 1)
+        self.assertRaises(ValueError, a.__setitem__, slice(0, 10, 2), [1,2])
+        self.assertRaises(TypeError, a.__getitem__, 'x', 1)
+        a[slice(2,10,3)] = [1,2,3]
+        self.assertEqual(a, self.type2test([0, 1, 1, 3, 4, 2, 6, 7, 3,
+                                            9, 10, 11, 12, 13, 14, 15,
+                                            16, 17, 18, 19]))
+
+    def test_reversed(self):
+        a = self.type2test(range(20))
+        r = reversed(a)
+        self.assertEqual(list(r), self.type2test(range(19, -1, -1)))
+        self.assertRaises(StopIteration, r.next)
+        self.assertEqual(list(reversed(self.type2test())),
+                         self.type2test())
+        # Bug 3689: make sure list-reversed-iterator doesn't have __len__
+        self.assertRaises(TypeError, len, reversed([1,2,3]))
+
+    def test_setitem(self):
+        a = self.type2test([0, 1])
+        a[0] = 0
+        a[1] = 100
+        self.assertEqual(a, self.type2test([0, 100]))
+        a[-1] = 200
+        self.assertEqual(a, self.type2test([0, 200]))
+        a[-2] = 100
+        self.assertEqual(a, self.type2test([100, 200]))
+        self.assertRaises(IndexError, a.__setitem__, -3, 200)
+        self.assertRaises(IndexError, a.__setitem__, 2, 200)
+
+        a = self.type2test([])
+        self.assertRaises(IndexError, a.__setitem__, 0, 200)
+        self.assertRaises(IndexError, a.__setitem__, -1, 200)
+        self.assertRaises(TypeError, a.__setitem__)
+
+        a = self.type2test([0,1,2,3,4])
+        a[0L] = 1
+        a[1L] = 2
+        a[2L] = 3
+        self.assertEqual(a, self.type2test([1,2,3,3,4]))
+        a[0] = 5
+        a[1] = 6
+        a[2] = 7
+        self.assertEqual(a, self.type2test([5,6,7,3,4]))
+        a[-2L] = 88
+        a[-1L] = 99
+        self.assertEqual(a, self.type2test([5,6,7,88,99]))
+        a[-2] = 8
+        a[-1] = 9
+        self.assertEqual(a, self.type2test([5,6,7,8,9]))
+
+    def test_delitem(self):
+        a = self.type2test([0, 1])
+        del a[1]
+        self.assertEqual(a, [0])
+        del a[0]
+        self.assertEqual(a, [])
+
+        a = self.type2test([0, 1])
+        del a[-2]
+        self.assertEqual(a, [1])
+        del a[-1]
+        self.assertEqual(a, [])
+
+        a = self.type2test([0, 1])
+        self.assertRaises(IndexError, a.__delitem__, -3)
+        self.assertRaises(IndexError, a.__delitem__, 2)
+
+        a = self.type2test([])
+        self.assertRaises(IndexError, a.__delitem__, 0)
+
+        self.assertRaises(TypeError, a.__delitem__)
+
+    def test_setslice(self):
+        l = [0, 1]
+        a = self.type2test(l)
+
+        for i in range(-3, 4):
+            a[:i] = l[:i]
+            self.assertEqual(a, l)
+            a2 = a[:]
+            a2[:i] = a[:i]
+            self.assertEqual(a2, a)
+            a[i:] = l[i:]
+            self.assertEqual(a, l)
+            a2 = a[:]
+            a2[i:] = a[i:]
+            self.assertEqual(a2, a)
+            for j in range(-3, 4):
+                a[i:j] = l[i:j]
+                self.assertEqual(a, l)
+                a2 = a[:]
+                a2[i:j] = a[i:j]
+                self.assertEqual(a2, a)
+
+        aa2 = a2[:]
+        aa2[:0] = [-2, -1]
+        self.assertEqual(aa2, [-2, -1, 0, 1])
+        aa2[0:] = []
+        self.assertEqual(aa2, [])
+
+        a = self.type2test([1, 2, 3, 4, 5])
+        a[:-1] = a
+        self.assertEqual(a, self.type2test([1, 2, 3, 4, 5, 5]))
+        a = self.type2test([1, 2, 3, 4, 5])
+        a[1:] = a
+        self.assertEqual(a, self.type2test([1, 1, 2, 3, 4, 5]))
+        a = self.type2test([1, 2, 3, 4, 5])
+        a[1:-1] = a
+        self.assertEqual(a, self.type2test([1, 1, 2, 3, 4, 5, 5]))
+
+        a = self.type2test([])
+        a[:] = tuple(range(10))
+        self.assertEqual(a, self.type2test(range(10)))
+
+        self.assertRaises(TypeError, a.__setslice__, 0, 1, 5)
+        self.assertRaises(TypeError, a.__setitem__, slice(0, 1, 5))
+
+        self.assertRaises(TypeError, a.__setslice__)
+        self.assertRaises(TypeError, a.__setitem__)
+
+    def test_delslice(self):
+        a = self.type2test([0, 1])
+        del a[1:2]
+        del a[0:1]
+        self.assertEqual(a, self.type2test([]))
+
+        a = self.type2test([0, 1])
+        del a[1L:2L]
+        del a[0L:1L]
+        self.assertEqual(a, self.type2test([]))
+
+        a = self.type2test([0, 1])
+        del a[-2:-1]
+        self.assertEqual(a, self.type2test([1]))
+
+        a = self.type2test([0, 1])
+        del a[-2L:-1L]
+        self.assertEqual(a, self.type2test([1]))
+
+        a = self.type2test([0, 1])
+        del a[1:]
+        del a[:1]
+        self.assertEqual(a, self.type2test([]))
+
+        a = self.type2test([0, 1])
+        del a[1L:]
+        del a[:1L]
+        self.assertEqual(a, self.type2test([]))
+
+        a = self.type2test([0, 1])
+        del a[-1:]
+        self.assertEqual(a, self.type2test([0]))
+
+        a = self.type2test([0, 1])
+        del a[-1L:]
+        self.assertEqual(a, self.type2test([0]))
+
+        a = self.type2test([0, 1])
+        del a[:]
+        self.assertEqual(a, self.type2test([]))
+
+    def test_append(self):
+        a = self.type2test([])
+        a.append(0)
+        a.append(1)
+        a.append(2)
+        self.assertEqual(a, self.type2test([0, 1, 2]))
+
+        self.assertRaises(TypeError, a.append)
+
+    def test_extend(self):
+        a1 = self.type2test([0])
+        a2 = self.type2test((0, 1))
+        a = a1[:]
+        a.extend(a2)
+        self.assertEqual(a, a1 + a2)
+
+        a.extend(self.type2test([]))
+        self.assertEqual(a, a1 + a2)
+
+        a.extend(a)
+        self.assertEqual(a, self.type2test([0, 0, 1, 0, 0, 1]))
+
+        a = self.type2test("spam")
+        a.extend("eggs")
+        self.assertEqual(a, list("spameggs"))
+
+        self.assertRaises(TypeError, a.extend, None)
+
+        self.assertRaises(TypeError, a.extend)
+
+    def test_insert(self):
+        a = self.type2test([0, 1, 2])
+        a.insert(0, -2)
+        a.insert(1, -1)
+        a.insert(2, 0)
+        self.assertEqual(a, [-2, -1, 0, 0, 1, 2])
+
+        b = a[:]
+        b.insert(-2, "foo")
+        b.insert(-200, "left")
+        b.insert(200, "right")
+        self.assertEqual(b, self.type2test(["left",-2,-1,0,0,"foo",1,2,"right"]))
+
+        self.assertRaises(TypeError, a.insert)
+
+    def test_pop(self):
+        a = self.type2test([-1, 0, 1])
+        a.pop()
+        self.assertEqual(a, [-1, 0])
+        a.pop(0)
+        self.assertEqual(a, [0])
+        self.assertRaises(IndexError, a.pop, 5)
+        a.pop(0)
+        self.assertEqual(a, [])
+        self.assertRaises(IndexError, a.pop)
+        self.assertRaises(TypeError, a.pop, 42, 42)
+        a = self.type2test([0, 10, 20, 30, 40])
+
+    def test_remove(self):
+        a = self.type2test([0, 0, 1])
+        a.remove(1)
+        self.assertEqual(a, [0, 0])
+        a.remove(0)
+        self.assertEqual(a, [0])
+        a.remove(0)
+        self.assertEqual(a, [])
+
+        self.assertRaises(ValueError, a.remove, 0)
+
+        self.assertRaises(TypeError, a.remove)
+
+        class BadExc(Exception):
+            pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                if other == 2:
+                    raise BadExc()
+                return False
+
+        a = self.type2test([0, 1, 2, 3])
+        self.assertRaises(BadExc, a.remove, BadCmp())
+
+        class BadCmp2(object):
+            def __eq__(self, other):
+                raise BadExc()
+
+        d = self.type2test('abcdefghcij')
+        d.remove('c')
+        self.assertEqual(d, self.type2test('abdefghcij'))
+        d.remove('c')
+        self.assertEqual(d, self.type2test('abdefghij'))
+        self.assertRaises(ValueError, d.remove, 'c')
+        self.assertEqual(d, self.type2test('abdefghij'))
+
+        # Handle comparison errors
+        d = self.type2test(['a', 'b', BadCmp2(), 'c'])
+        e = self.type2test(d)
+        self.assertRaises(BadExc, d.remove, 'c')
+        for x, y in zip(d, e):
+            # verify that original order and values are retained.
+            self.assertIs(x, y)
+
+    def test_count(self):
+        a = self.type2test([0, 1, 2])*3
+        self.assertEqual(a.count(0), 3)
+        self.assertEqual(a.count(1), 3)
+        self.assertEqual(a.count(3), 0)
+
+        self.assertRaises(TypeError, a.count)
+
+        class BadExc(Exception):
+            pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                if other == 2:
+                    raise BadExc()
+                return False
+
+        self.assertRaises(BadExc, a.count, BadCmp())
+
+    def test_index(self):
+        u = self.type2test([0, 1])
+        self.assertEqual(u.index(0), 0)
+        self.assertEqual(u.index(1), 1)
+        self.assertRaises(ValueError, u.index, 2)
+
+        u = self.type2test([-2, -1, 0, 0, 1, 2])
+        self.assertEqual(u.count(0), 2)
+        self.assertEqual(u.index(0), 2)
+        self.assertEqual(u.index(0, 2), 2)
+        self.assertEqual(u.index(-2, -10), 0)
+        self.assertEqual(u.index(0, 3), 3)
+        self.assertEqual(u.index(0, 3, 4), 3)
+        self.assertRaises(ValueError, u.index, 2, 0, -10)
+
+        self.assertRaises(TypeError, u.index)
+
+        class BadExc(Exception):
+            pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                if other == 2:
+                    raise BadExc()
+                return False
+
+        a = self.type2test([0, 1, 2, 3])
+        self.assertRaises(BadExc, a.index, BadCmp())
+
+        a = self.type2test([-2, -1, 0, 0, 1, 2])
+        self.assertEqual(a.index(0), 2)
+        self.assertEqual(a.index(0, 2), 2)
+        self.assertEqual(a.index(0, -4), 2)
+        self.assertEqual(a.index(-2, -10), 0)
+        self.assertEqual(a.index(0, 3), 3)
+        self.assertEqual(a.index(0, -3), 3)
+        self.assertEqual(a.index(0, 3, 4), 3)
+        self.assertEqual(a.index(0, -3, -2), 3)
+        self.assertEqual(a.index(0, -4*sys.maxint, 4*sys.maxint), 2)
+        self.assertRaises(ValueError, a.index, 0, 4*sys.maxint,-4*sys.maxint)
+        self.assertRaises(ValueError, a.index, 2, 0, -10)
+        a.remove(0)
+        self.assertRaises(ValueError, a.index, 2, 0, 4)
+        self.assertEqual(a, self.type2test([-2, -1, 0, 1, 2]))
+
+        # Test modifying the list during index's iteration
+        class EvilCmp(object):
+            def __init__(self, victim):
+                self.victim = victim
+            def __eq__(self, other):
+                del self.victim[:]
+                return False
+        a = self.type2test()
+        a[:] = [EvilCmp(a) for _ in xrange(100)]
+        # This used to seg fault before patch #1005778
+        self.assertRaises(ValueError, a.index, None)
+
+    def test_reverse(self):
+        u = self.type2test([-2, -1, 0, 1, 2])
+        u2 = u[:]
+        u.reverse()
+        self.assertEqual(u, [2, 1, 0, -1, -2])
+        u.reverse()
+        self.assertEqual(u, u2)
+
+        self.assertRaises(TypeError, u.reverse, 42)
+
+    def test_sort(self):
+        with test_support.check_py3k_warnings(
+                ("the cmp argument is not supported", DeprecationWarning)):
+            self._test_sort()
+
+    def _test_sort(self):
+        u = self.type2test([1, 0])
+        u.sort()
+        self.assertEqual(u, [0, 1])
+
+        u = self.type2test([2,1,0,-1,-2])
+        u.sort()
+        self.assertEqual(u, self.type2test([-2,-1,0,1,2]))
+
+        self.assertRaises(TypeError, u.sort, 42, 42)
+
+        def revcmp(a, b):
+            return cmp(b, a)
+        u.sort(revcmp)
+        self.assertEqual(u, self.type2test([2,1,0,-1,-2]))
+
+        # The following dumps core in unpatched Python 1.5:
+        def myComparison(x,y):
+            return cmp(x%3, y%7)
+        z = self.type2test(range(12))
+        z.sort(myComparison)
+
+        self.assertRaises(TypeError, z.sort, 2)
+
+        def selfmodifyingComparison(x,y):
+            z.append(1)
+            return cmp(x, y)
+        self.assertRaises(ValueError, z.sort, selfmodifyingComparison)
+
+        self.assertRaises(TypeError, z.sort, lambda x, y: 's')
+
+        self.assertRaises(TypeError, z.sort, 42, 42, 42, 42)
+
+    def test_slice(self):
+        u = self.type2test("spam")
+        u[:2] = "h"
+        self.assertEqual(u, list("ham"))
+
+    def test_iadd(self):
+        super(CommonTest, self).test_iadd()
+        u = self.type2test([0, 1])
+        u2 = u
+        u += [2, 3]
+        self.assertIs(u, u2)
+
+        u = self.type2test("spam")
+        u += "eggs"
+        self.assertEqual(u, self.type2test("spameggs"))
+
+        self.assertRaises(TypeError, u.__iadd__, None)
+
+    def test_imul(self):
+        u = self.type2test([0, 1])
+        u *= 3
+        self.assertEqual(u, self.type2test([0, 1, 0, 1, 0, 1]))
+        u *= 0
+        self.assertEqual(u, self.type2test([]))
+        s = self.type2test([])
+        oldid = id(s)
+        s *= 10
+        self.assertEqual(id(s), oldid)
+
+    def test_extendedslicing(self):
+        #  subscript
+        a = self.type2test([0,1,2,3,4])
+
+        #  deletion
+        del a[::2]
+        self.assertEqual(a, self.type2test([1,3]))
+        a = self.type2test(range(5))
+        del a[1::2]
+        self.assertEqual(a, self.type2test([0,2,4]))
+        a = self.type2test(range(5))
+        del a[1::-2]
+        self.assertEqual(a, self.type2test([0,2,3,4]))
+        a = self.type2test(range(10))
+        del a[::1000]
+        self.assertEqual(a, self.type2test([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+        #  assignment
+        a = self.type2test(range(10))
+        a[::2] = [-1]*5
+        self.assertEqual(a, self.type2test([-1, 1, -1, 3, -1, 5, -1, 7, -1, 9]))
+        a = self.type2test(range(10))
+        a[::-4] = [10]*3
+        self.assertEqual(a, self.type2test([0, 10, 2, 3, 4, 10, 6, 7, 8 ,10]))
+        a = self.type2test(range(4))
+        a[::-1] = a
+        self.assertEqual(a, self.type2test([3, 2, 1, 0]))
+        a = self.type2test(range(10))
+        b = a[:]
+        c = a[:]
+        a[2:3] = self.type2test(["two", "elements"])
+        b[slice(2,3)] = self.type2test(["two", "elements"])
+        c[2:3:] = self.type2test(["two", "elements"])
+        self.assertEqual(a, b)
+        self.assertEqual(a, c)
+        a = self.type2test(range(10))
+        a[::2] = tuple(range(5))
+        self.assertEqual(a, self.type2test([0, 1, 1, 3, 2, 5, 3, 7, 4, 9]))
+        # test issue7788
+        a = self.type2test(range(10))
+        del a[9::1<<333]
+
+    def test_constructor_exception_handling(self):
+        # Bug #1242657
+        class F(object):
+            def __iter__(self):
+                raise KeyboardInterrupt
+        self.assertRaises(KeyboardInterrupt, list, F())
+
+    def test_exhausted_iterator(self):
+        a = self.type2test([1, 2, 3])
+        exhit = iter(a)
+        empit = iter(a)
+        for x in exhit:  # exhaust the iterator
+            next(empit)  # not exhausted
+        a.append(9)
+        self.assertEqual(list(exhit), [])
+        self.assertEqual(list(empit), [9])
+        self.assertEqual(a, self.type2test([1, 2, 3, 9]))

--- a/third_party/stdlib/test/mapping_tests.py
+++ b/third_party/stdlib/test/mapping_tests.py
@@ -198,7 +198,7 @@ class BasicTestMappingProtocol(unittest.TestCase):
         self.assertRaises((TypeError, AttributeError), d.update, 42)
 
         outerself = self
-        class SimpleUserDict:
+        class SimpleUserDict(object):
             def __init__(self):
                 self.d = outerself.reference
             def keys(self):
@@ -220,16 +220,16 @@ class BasicTestMappingProtocol(unittest.TestCase):
         class Exc(Exception): pass
 
         d = self._empty_mapping()
-        class FailingUserDict:
+        class FailingUserDict(object):
             def keys(self):
                 raise Exc
         self.assertRaises(Exc, d.update, FailingUserDict())
 
         d.clear()
 
-        class FailingUserDict:
+        class FailingUserDict(object):
             def keys(self):
-                class BogonIter:
+                class BogonIter(object):
                     def __init__(self):
                         self.i = 1
                     def __iter__(self):
@@ -244,9 +244,9 @@ class BasicTestMappingProtocol(unittest.TestCase):
                 return key
         self.assertRaises(Exc, d.update, FailingUserDict())
 
-        class FailingUserDict:
+        class FailingUserDict(object):
             def keys(self):
-                class BogonIter:
+                class BogonIter(object):
                     def __init__(self):
                         self.i = ord('a')
                     def __iter__(self):
@@ -425,7 +425,7 @@ class TestMappingProtocol(BasicTestMappingProtocol):
         d.update(self._full_mapping({1:2, 3:4, 5:6}).iteritems())
         self.assertEqual(d, {1:2, 2:4, 3:4, 5:6})
 
-        class SimpleUserDict:
+        class SimpleUserDict(object):
             def __init__(self):
                 self.d = {1:1, 2:2, 3:3}
             def keys(self):

--- a/third_party/stdlib/test/test_list.py
+++ b/third_party/stdlib/test/test_list.py
@@ -1,0 +1,80 @@
+import sys
+import unittest
+from test import test_support, list_tests
+
+class ListTest(list_tests.CommonTest):
+    type2test = list
+
+    def test_basic(self):
+        self.assertEqual(list([]), [])
+        l0_3 = [0, 1, 2, 3]
+        l0_3_bis = list(l0_3)
+        self.assertEqual(l0_3, l0_3_bis)
+        self.assertTrue(l0_3 is not l0_3_bis)
+        self.assertEqual(list(()), [])
+        self.assertEqual(list((0, 1, 2, 3)), [0, 1, 2, 3])
+        self.assertEqual(list(''), [])
+        self.assertEqual(list('spam'), ['s', 'p', 'a', 'm'])
+
+        if sys.maxsize == 0x7fffffff:
+            # This test can currently only work on 32-bit machines.
+            # XXX If/when PySequence_Length() returns a ssize_t, it should be
+            # XXX re-enabled.
+            # Verify clearing of bug #556025.
+            # This assumes that the max data size (sys.maxint) == max
+            # address size this also assumes that the address size is at
+            # least 4 bytes with 8 byte addresses, the bug is not well
+            # tested
+            #
+            # Note: This test is expected to SEGV under Cygwin 1.3.12 or
+            # earlier due to a newlib bug.  See the following mailing list
+            # thread for the details:
+
+            #     http://sources.redhat.com/ml/newlib/2002/msg00369.html
+            self.assertRaises(MemoryError, list, xrange(sys.maxint // 2))
+
+        # This code used to segfault in Py2.4a3
+        x = []
+        x.extend(-y for y in x)
+        self.assertEqual(x, [])
+
+    def test_truth(self):
+        super(ListTest, self).test_truth()
+        self.assertTrue(not [])
+        self.assertTrue([42])
+
+    def test_identity(self):
+        self.assertTrue([] is not [])
+
+    def test_len(self):
+        super(ListTest, self).test_len()
+        self.assertEqual(len([]), 0)
+        self.assertEqual(len([0]), 1)
+        self.assertEqual(len([0, 1, 2]), 3)
+
+    @unittest.expectedFailure
+    def test_overflow(self):
+        lst = [4, 5, 6, 7]
+        n = int((sys.maxsize*2+2) // len(lst))
+        def mul(a, b): return a * b
+        def imul(a, b): a *= b
+        self.assertRaises((MemoryError, OverflowError), mul, lst, n)
+        self.assertRaises((MemoryError, OverflowError), imul, lst, n)
+
+def test_main(verbose=None):
+    test_support.run_unittest(ListTest)
+
+    # verify reference counting
+    # import sys
+    # if verbose and hasattr(sys, "gettotalrefcount"):
+    #     import gc
+    #     counts = [None] * 5
+    #     for i in xrange(len(counts)):
+    #         test_support.run_unittest(ListTest)
+    #         gc.collect()
+    #         counts[i] = sys.gettotalrefcount()
+    #     print counts
+
+
+if __name__ == "__main__":
+    test_main(verbose=True)

--- a/third_party/stdlib/test/test_slice.py
+++ b/third_party/stdlib/test/test_slice.py
@@ -1,0 +1,150 @@
+# tests for slice objects; in particular the indices method.
+
+import unittest
+import weakref
+
+# from cPickle import loads, dumps
+from test import test_support
+
+import sys
+
+class SliceTest(unittest.TestCase):
+
+    def test_constructor(self):
+        self.assertRaises(TypeError, slice)
+        self.assertRaises(TypeError, slice, 1, 2, 3, 4)
+
+    def test_repr(self):
+        self.assertEqual(repr(slice(1, 2, 3)), "slice(1, 2, 3)")
+
+    def test_hash(self):
+        # Verify clearing of SF bug #800796
+        self.assertRaises(TypeError, hash, slice(5))
+        with self.assertRaises(TypeError):
+            slice(5).__hash__()
+
+    @unittest.expectedFailure
+    def test_cmp(self):
+        s1 = slice(1, 2, 3)
+        s2 = slice(1, 2, 3)
+        s3 = slice(1, 2, 4)
+        self.assertEqual(s1, s2)
+        self.assertNotEqual(s1, s3)
+
+        class Exc(Exception):
+            pass
+
+        class BadCmp(object):
+            def __eq__(self, other):
+                raise Exc
+            __hash__ = None # Silence Py3k warning
+
+        s1 = slice(BadCmp())
+        s2 = slice(BadCmp())
+        self.assertRaises(Exc, cmp, s1, s2)
+        self.assertEqual(s1, s1)
+
+        s1 = slice(1, BadCmp())
+        s2 = slice(1, BadCmp())
+        self.assertEqual(s1, s1)
+        self.assertRaises(Exc, cmp, s1, s2)
+
+        s1 = slice(1, 2, BadCmp())
+        s2 = slice(1, 2, BadCmp())
+        self.assertEqual(s1, s1)
+        self.assertRaises(Exc, cmp, s1, s2)
+
+    def test_members(self):
+        s = slice(1)
+        self.assertEqual(s.start, None)
+        self.assertEqual(s.stop, 1)
+        self.assertEqual(s.step, None)
+
+        s = slice(1, 2)
+        self.assertEqual(s.start, 1)
+        self.assertEqual(s.stop, 2)
+        self.assertEqual(s.step, None)
+
+        s = slice(1, 2, 3)
+        self.assertEqual(s.start, 1)
+        self.assertEqual(s.stop, 2)
+        self.assertEqual(s.step, 3)
+
+        class AnyClass(object):
+            pass
+
+        obj = AnyClass()
+        s = slice(obj)
+        self.assertTrue(s.stop is obj)
+
+    @unittest.expectedFailure
+    def test_indices(self):
+        self.assertEqual(slice(None           ).indices(10), (0, 10,  1))
+        self.assertEqual(slice(None,  None,  2).indices(10), (0, 10,  2))
+        self.assertEqual(slice(1,     None,  2).indices(10), (1, 10,  2))
+        self.assertEqual(slice(None,  None, -1).indices(10), (9, -1, -1))
+        self.assertEqual(slice(None,  None, -2).indices(10), (9, -1, -2))
+        self.assertEqual(slice(3,     None, -2).indices(10), (3, -1, -2))
+        # issue 3004 tests
+        self.assertEqual(slice(None, -9).indices(10), (0, 1, 1))
+        self.assertEqual(slice(None, -10).indices(10), (0, 0, 1))
+        self.assertEqual(slice(None, -11).indices(10), (0, 0, 1))
+        self.assertEqual(slice(None, -10, -1).indices(10), (9, 0, -1))
+        self.assertEqual(slice(None, -11, -1).indices(10), (9, -1, -1))
+        self.assertEqual(slice(None, -12, -1).indices(10), (9, -1, -1))
+        self.assertEqual(slice(None, 9).indices(10), (0, 9, 1))
+        self.assertEqual(slice(None, 10).indices(10), (0, 10, 1))
+        self.assertEqual(slice(None, 11).indices(10), (0, 10, 1))
+        self.assertEqual(slice(None, 8, -1).indices(10), (9, 8, -1))
+        self.assertEqual(slice(None, 9, -1).indices(10), (9, 9, -1))
+        self.assertEqual(slice(None, 10, -1).indices(10), (9, 9, -1))
+
+        self.assertEqual(
+            slice(-100,  100     ).indices(10),
+            slice(None).indices(10)
+        )
+        self.assertEqual(
+            slice(100,  -100,  -1).indices(10),
+            slice(None, None, -1).indices(10)
+        )
+        self.assertEqual(slice(-100L, 100L, 2L).indices(10), (0, 10,  2))
+
+        self.assertEqual(range(10)[::sys.maxint - 1], [0])
+
+        self.assertRaises(OverflowError, slice(None).indices, 1L<<100)
+
+    @unittest.expectedFailure
+    def test_setslice_without_getslice(self):
+        tmp = []
+        class X(object):
+            def __setslice__(self, i, j, k):
+                tmp.append((i, j, k))
+
+        x = X()
+        with test_support.check_py3k_warnings():
+            x[1:2] = 42
+        self.assertEqual(tmp, [(1, 2, 42)])
+
+    # def test_pickle(self):
+    #     s = slice(10, 20, 3)
+    #     for protocol in (0,1,2):
+    #         t = loads(dumps(s, protocol))
+    #         self.assertEqual(s, t)
+    #         self.assertEqual(s.indices(15), t.indices(15))
+    #         self.assertNotEqual(id(s), id(t))
+
+    @unittest.expectedFailure
+    def test_cycle(self):
+        class myobj(object): pass
+        o = myobj()
+        o.s = slice(o)
+        w = weakref.ref(o)
+        o = None
+        test_support.gc_collect()
+        self.assertIsNone(w())
+
+def test_main():
+    test_support.run_unittest(SliceTest)
+
+if __name__ == "__main__":
+    test_main()

--- a/third_party/stdlib/unittest/__init__.py
+++ b/third_party/stdlib/unittest/__init__.py
@@ -45,7 +45,7 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 __all__ = ['TestResult', 'TestCase', 'TestSuite',
-           'TextTestRunner', 'TestLoader', 'FunctionTestCase', 'main',
+           'TextTestRunner', 'TestLoader', 'FunctionTestCase',
            'defaultTestLoader', 'SkipTest', 'skip', 'skipIf', 'skipUnless',
            'expectedFailure', 'TextTestResult', 'installHandler',
            'registerResult', 'removeResult', 'removeHandler']


### PR DESCRIPTION
- Added stdlib list and slice tests
- Added those to Makefile
- Removed seq_tests, mapping_tests, `*_tests` from Makefile, there are just dependent by `test_*.py`, since they don't actually test themselves.
- minor chore on `unittest/__init__.py`
