### PR TITLE
Implement the sequence `count` method

### DIFF
--- a/runtime/list.go
+++ b/runtime/list.go
@@ -163,6 +163,14 @@ func listAppend(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	return None, nil
 }
 
+func listCount(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
+	argc := len(args)
+	if argc != 2 {
+		return nil, f.RaiseType(TypeErrorType, fmt.Sprintf("count() takes exactly one argument (%d given)", argc))
+	}
+	return seqCount(f, args[0], args[1])
+}
+
 func listExtend(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	argc := len(args)
 	if argc != 2 {
@@ -391,6 +399,7 @@ func listSort(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 
 func initListType(dict map[string]*Object) {
 	dict["append"] = newBuiltinFunction("append", listAppend).ToObject()
+	dict["count"] = newBuiltinFunction("count", listCount).ToObject()
 	dict["extend"] = newBuiltinFunction("extend", listExtend).ToObject()
 	dict["insert"] = newBuiltinFunction("insert", listInsert).ToObject()
 	dict["pop"] = newBuiltinFunction("pop", listPop).ToObject()

--- a/runtime/list_test.go
+++ b/runtime/list_test.go
@@ -79,6 +79,19 @@ func TestListCompare(t *testing.T) {
 	}
 }
 
+func TestListCount(t *testing.T) {
+	cases := []invokeTestCase{
+		{args: wrapArgs(NewList(), NewInt(1)), want: NewInt(0).ToObject()},
+		{args: wrapArgs(NewList(None, None, None), None), want: NewInt(3).ToObject()},
+		{args: wrapArgs(newTestList()), wantExc: mustCreateException(TypeErrorType, "count() takes exactly one argument (1 given)")},
+	}
+	for _, cas := range cases {
+		if err := runInvokeMethodTestCase(ListType, "count", &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
+
 func BenchmarkListContains(b *testing.B) {
 	b.Run("false-3", func(b *testing.B) {
 		t := newTestList("foo", 42, "bar").ToObject()

--- a/runtime/seq.go
+++ b/runtime/seq.go
@@ -129,6 +129,28 @@ func seqContains(f *Frame, iterable *Object, v *Object) (*Object, *BaseException
 	return GetBool(foundEqItem).ToObject(), raised
 }
 
+func seqCount(f *Frame, iterable *Object, v *Object) (*Object, *BaseException) {
+	count := 0
+	raised := seqForEach(f, iterable, func(o *Object) *BaseException {
+		eq, raised := Eq(f, o, v)
+		if raised != nil {
+			return raised
+		}
+		t, raised := IsTrue(f, eq)
+		if raised != nil {
+			return raised
+		}
+		if t {
+			count++
+		}
+		return nil
+	})
+	if raised != nil {
+		return nil, raised
+	}
+	return NewInt(count).ToObject(), nil
+}
+
 func seqFindFirst(f *Frame, iterable *Object, pred func(*Object) (bool, *BaseException)) (bool, *BaseException) {
 	iter, raised := Iter(f, iterable)
 	if raised != nil {

--- a/testing/list_test.py
+++ b/testing/list_test.py
@@ -98,3 +98,15 @@ try:
   assert AssertionError
 except TypeError:
   pass
+
+# Test count
+assert [].count(0) == 0
+assert [1, 2, 3].count(2) == 1
+assert ["a", "b", "a", "a"].count("a") == 3
+assert ([2] * 20).count(2) == 20
+
+try:
+  [].count()
+  assert AssertionError
+except TypeError:
+  pass


### PR DESCRIPTION
As specified here:

* https://docs.python.org/2/library/stdtypes.html#sequence-types-str-unicode-list-tuple-bytearray-buffer-xrange

This commit only uses the sequence count method for `list.count`,
but it can easily be applied to other sequence types in follow-on
commits.