### PR TITLE
Add a bunch of micro benchmarks.

### DIFF
--- a/runtime/int_test.go
+++ b/runtime/int_test.go
@@ -16,6 +16,7 @@ package grumpy
 
 import (
 	"math/big"
+	"runtime"
 	"testing"
 )
 
@@ -202,15 +203,19 @@ func TestIntNewInterned(t *testing.T) {
 
 func BenchmarkIntNew(b *testing.B) {
 	b.Run("interned", func(b *testing.B) {
+		var ret *Object
 		for i := 0; i < b.N; i++ {
-			_ = NewInt(1).ToObject()
+			ret = NewInt(1).ToObject()
 		}
+		runtime.KeepAlive(ret)
 	})
 
 	b.Run("not interned", func(b *testing.B) {
+		var ret *Object
 		for i := 0; i < b.N; i++ {
-			_ = NewInt(internedIntMax + 5).ToObject()
+			ret = NewInt(internedIntMax + 5).ToObject()
 		}
+		runtime.KeepAlive(ret)
 	})
 }
 

--- a/runtime/str_test.go
+++ b/runtime/str_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -27,6 +28,14 @@ func TestNewStr(t *testing.T) {
 	if !reflect.DeepEqual(s, expected) {
 		t.Errorf(`NewStr("foo") = %+v, expected %+v`, *s, *expected)
 	}
+}
+
+func BenchmarkNewStr(b *testing.B) {
+	var ret *Str
+	for i := 0; i < b.N; i++ {
+		ret = NewStr("foo")
+	}
+	runtime.KeepAlive(ret)
 }
 
 // # On a 64bit system:


### PR DESCRIPTION
Method covered by new benchmarks:
* Dict.GetItem
* Dict.IterItems
* Dict.IterKeys
* Dict.IterValues
* NewInt - Fixed so that references aren't elided anymore.
* NewStr

I have some improvements in the Dict area and I thought it might be good to get some benchmarks on the ground first.