### PR TITLE
Make internal dict iterator structs not allocate.

### DIFF
--- a/runtime/dict.go
+++ b/runtime/dict.go
@@ -216,8 +216,8 @@ type dictEntryIterator struct {
 
 // newDictEntryIterator creates a dictEntryIterator object for d. It assumes
 // that d.mutex is held by the caller.
-func newDictEntryIterator(d *Dict) *dictEntryIterator {
-	return &dictEntryIterator{table: d.loadTable()}
+func newDictEntryIterator(d *Dict) dictEntryIterator {
+	return dictEntryIterator{table: d.loadTable()}
 }
 
 // next advances this iterator to the next occupied entry and returns it. The
@@ -249,8 +249,8 @@ type dictVersionGuard struct {
 	version int64
 }
 
-func newDictVersionGuard(d *Dict) *dictVersionGuard {
-	return &dictVersionGuard{d, d.loadVersion()}
+func newDictVersionGuard(d *Dict) dictVersionGuard {
+	return dictVersionGuard{d, d.loadVersion()}
 }
 
 // check returns false if the dict held by g has changed since g was created,
@@ -787,8 +787,8 @@ func initDictType(dict map[string]*Object) {
 
 type dictItemIterator struct {
 	Object
-	iter  *dictEntryIterator
-	guard *dictVersionGuard
+	iter  dictEntryIterator
+	guard dictVersionGuard
 }
 
 // newDictItemIterator creates a dictItemIterator object for d. It assumes that
@@ -815,7 +815,7 @@ func dictItemIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
 
 func dictItemIteratorNext(f *Frame, o *Object) (ret *Object, raised *BaseException) {
 	iter := toDictItemIteratorUnsafe(o)
-	entry, raised := dictIteratorNext(f, iter.iter, iter.guard)
+	entry, raised := dictIteratorNext(f, &iter.iter, &iter.guard)
 	if raised != nil {
 		return nil, raised
 	}
@@ -830,8 +830,8 @@ func initDictItemIteratorType(map[string]*Object) {
 
 type dictKeyIterator struct {
 	Object
-	iter  *dictEntryIterator
-	guard *dictVersionGuard
+	iter  dictEntryIterator
+	guard dictVersionGuard
 }
 
 // newDictKeyIterator creates a dictKeyIterator object for d. It assumes that
@@ -858,7 +858,7 @@ func dictKeyIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
 
 func dictKeyIteratorNext(f *Frame, o *Object) (*Object, *BaseException) {
 	iter := toDictKeyIteratorUnsafe(o)
-	entry, raised := dictIteratorNext(f, iter.iter, iter.guard)
+	entry, raised := dictIteratorNext(f, &iter.iter, &iter.guard)
 	if raised != nil {
 		return nil, raised
 	}
@@ -873,8 +873,8 @@ func initDictKeyIteratorType(map[string]*Object) {
 
 type dictValueIterator struct {
 	Object
-	iter  *dictEntryIterator
-	guard *dictVersionGuard
+	iter  dictEntryIterator
+	guard dictVersionGuard
 }
 
 // newDictValueIterator creates a dictValueIterator object for d. It assumes
@@ -901,7 +901,7 @@ func dictValueIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
 
 func dictValueIteratorNext(f *Frame, o *Object) (*Object, *BaseException) {
 	iter := toDictValueIteratorUnsafe(o)
-	entry, raised := dictIteratorNext(f, iter.iter, iter.guard)
+	entry, raised := dictIteratorNext(f, &iter.iter, &iter.guard)
 	if raised != nil {
 		return nil, raised
 	}


### PR DESCRIPTION
Reasonable wins on the number of allocations resulting in some modest speed gains as well as a small reduction in total memory footprint.

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkDictIterItems/0-elements      603           521           -13.60%
BenchmarkDictIterItems/1-elements      677           626           -7.53%
BenchmarkDictIterItems/2-elements      795           692           -12.96%
BenchmarkDictIterItems/3-elements      873           811           -7.10%
BenchmarkDictIterItems/4-elements      985           880           -10.66%
BenchmarkDictIterItems/5-elements      1050          1039          -1.05%
BenchmarkDictIterItems/6-elements      1377          1269          -7.84%
BenchmarkDictIterItems/7-elements      1452          1371          -5.58%
BenchmarkDictIterItems/8-elements      1554          1447          -6.89%
BenchmarkDictIterKeys/0-elements       602           522           -13.29%
BenchmarkDictIterKeys/1-elements       619           537           -13.25%
BenchmarkDictIterKeys/2-elements       625           549           -12.16%
BenchmarkDictIterKeys/3-elements       639           560           -12.36%
BenchmarkDictIterKeys/4-elements       651           572           -12.14%
BenchmarkDictIterKeys/5-elements       667           586           -12.14%
BenchmarkDictIterKeys/6-elements       927           846           -8.74%
BenchmarkDictIterKeys/7-elements       939           857           -8.73%
BenchmarkDictIterKeys/8-elements       946           865           -8.56%
BenchmarkDictIterValues/0-elements     598           519           -13.21%
BenchmarkDictIterValues/1-elements     609           536           -11.99%
BenchmarkDictIterValues/2-elements     626           546           -12.78%
BenchmarkDictIterValues/3-elements     641           559           -12.79%
BenchmarkDictIterValues/4-elements     648           572           -11.73%
BenchmarkDictIterValues/5-elements     664           587           -11.60%
BenchmarkDictIterValues/6-elements     918           842           -8.28%
BenchmarkDictIterValues/7-elements     937           852           -9.07%
BenchmarkDictIterValues/8-elements     949           867           -8.64%

benchmark                              old allocs     new allocs     delta
BenchmarkDictIterItems/0-elements      8              6              -25.00%
BenchmarkDictIterItems/1-elements      10             8              -20.00%
BenchmarkDictIterItems/2-elements      12             10             -16.67%
BenchmarkDictIterItems/3-elements      14             12             -14.29%
BenchmarkDictIterItems/4-elements      16             14             -12.50%
BenchmarkDictIterItems/5-elements      18             16             -11.11%
BenchmarkDictIterItems/6-elements      20             18             -10.00%
BenchmarkDictIterItems/7-elements      22             20             -9.09%
BenchmarkDictIterItems/8-elements      24             22             -8.33%
BenchmarkDictIterKeys/0-elements       8              6              -25.00%
BenchmarkDictIterKeys/1-elements       8              6              -25.00%
BenchmarkDictIterKeys/2-elements       8              6              -25.00%
BenchmarkDictIterKeys/3-elements       8              6              -25.00%
BenchmarkDictIterKeys/4-elements       8              6              -25.00%
BenchmarkDictIterKeys/5-elements       8              6              -25.00%
BenchmarkDictIterKeys/6-elements       8              6              -25.00%
BenchmarkDictIterKeys/7-elements       8              6              -25.00%
BenchmarkDictIterKeys/8-elements       8              6              -25.00%
BenchmarkDictIterValues/0-elements     8              6              -25.00%
BenchmarkDictIterValues/1-elements     8              6              -25.00%
BenchmarkDictIterValues/2-elements     8              6              -25.00%
BenchmarkDictIterValues/3-elements     8              6              -25.00%
BenchmarkDictIterValues/4-elements     8              6              -25.00%
BenchmarkDictIterValues/5-elements     8              6              -25.00%
BenchmarkDictIterValues/6-elements     8              6              -25.00%
BenchmarkDictIterValues/7-elements     8              6              -25.00%
BenchmarkDictIterValues/8-elements     8              6              -25.00%

benchmark                              old bytes     new bytes     delta
BenchmarkDictIterItems/0-elements      336           320           -4.76%
BenchmarkDictIterItems/1-elements      400           384           -4.00%
BenchmarkDictIterItems/2-elements      464           448           -3.45%
BenchmarkDictIterItems/3-elements      528           512           -3.03%
BenchmarkDictIterItems/4-elements      592           576           -2.70%
BenchmarkDictIterItems/5-elements      656           640           -2.44%
BenchmarkDictIterItems/6-elements      720           704           -2.22%
BenchmarkDictIterItems/7-elements      784           768           -2.04%
BenchmarkDictIterItems/8-elements      848           832           -1.89%
BenchmarkDictIterKeys/0-elements       336           320           -4.76%
BenchmarkDictIterKeys/1-elements       336           320           -4.76%
BenchmarkDictIterKeys/2-elements       336           320           -4.76%
BenchmarkDictIterKeys/3-elements       336           320           -4.76%
BenchmarkDictIterKeys/4-elements       336           320           -4.76%
BenchmarkDictIterKeys/5-elements       336           320           -4.76%
BenchmarkDictIterKeys/6-elements       336           320           -4.76%
BenchmarkDictIterKeys/7-elements       336           320           -4.76%
BenchmarkDictIterKeys/8-elements       336           320           -4.76%
BenchmarkDictIterValues/0-elements     336           320           -4.76%
BenchmarkDictIterValues/1-elements     336           320           -4.76%
BenchmarkDictIterValues/2-elements     336           320           -4.76%
BenchmarkDictIterValues/3-elements     336           320           -4.76%
BenchmarkDictIterValues/4-elements     336           320           -4.76%
BenchmarkDictIterValues/5-elements     336           320           -4.76%
BenchmarkDictIterValues/6-elements     336           320           -4.76%
BenchmarkDictIterValues/7-elements     336           320           -4.76%
BenchmarkDictIterValues/8-elements     336           320           -4.76%
```