### PR TITLE
Changed install section of Makefile to work on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,12 +289,12 @@ $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME
 # ------------------------------------------------------------------------------
 
 install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
-        mkdir -p "$(DESTDIR)/usr/bin"
-        # Binary executables
-        install -m755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
-        install -m755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
-        # Python module
-        install -d "$(DESTDIR)"{/usr/lib/go,"$(PY_INSTALL_DIR)"}
-        cp -rv "$(PY_DIR)/grumpy" "$(DESTDIR)$(PY_INSTALL_DIR)"
-        # Go package and sources
-        cp -rv build/pkg build/src "$(DESTDIR)/usr/lib/go/"
+	mkdir -p "$(DESTDIR)/usr/bin"
+	# Binary executables
+	install -m755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
+	install -m755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
+	# Python module
+	install -d "$(DESTDIR)"{/usr/lib/go,"$(PY_INSTALL_DIR)"}
+	cp -rv "$(PY_DIR)/grumpy" "$(DESTDIR)$(PY_INSTALL_DIR)"
+	# Go package and sources
+	cp -rv build/pkg build/src "$(DESTDIR)/usr/lib/go/"

--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,8 @@ $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME
 # ------------------------------------------------------------------------------
 
 install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
-	mkdir -p "$(DESTDIR)/usr/bin"
 	# Binary executables
+	install -d "$(DESTDIR)/usr/bin"
 	install -m755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
 	install -m755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
 	# Python module

--- a/Makefile
+++ b/Makefile
@@ -289,16 +289,6 @@ $(BENCHMARK_BINS): build/benchmarks/%_benchmark: build/benchmarks/%.go $(RUNTIME
 # ------------------------------------------------------------------------------
 
 install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
-	# Binary executables
-	install -Dm755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
-	install -Dm755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
-	# Python module
-	install -d "$(DESTDIR)"{/usr/lib/go,"$(PY_INSTALL_DIR)"}
-	cp -rv --no-preserve=ownership "$(PY_DIR)/grumpy" "$(DESTDIR)$(PY_INSTALL_DIR)"
-	# Go package and sources
-	cp -rv --no-preserve=ownership build/pkg build/src "$(DESTDIR)/usr/lib/go/"
-
-install_osx: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
         mkdir -p "$(DESTDIR)/usr/bin"
         # Binary executables
         install -m755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"

--- a/Makefile
+++ b/Makefile
@@ -298,3 +298,13 @@ install: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
 	# Go package and sources
 	cp -rv --no-preserve=ownership build/pkg build/src "$(DESTDIR)/usr/lib/go/"
 
+install_osx: $(RUNNER_BIN) $(COMPILER) $(RUNTIME) $(STDLIB)
+        mkdir -p "$(DESTDIR)/usr/bin"
+        # Binary executables
+        install -m755 build/bin/grumpc "$(DESTDIR)/usr/bin/grumpc"
+        install -m755 build/bin/grumprun "$(DESTDIR)/usr/bin/grumprun"
+        # Python module
+        install -d "$(DESTDIR)"{/usr/lib/go,"$(PY_INSTALL_DIR)"}
+        cp -rv "$(PY_DIR)/grumpy" "$(DESTDIR)$(PY_INSTALL_DIR)"
+        # Go package and sources
+        cp -rv build/pkg build/src "$(DESTDIR)/usr/lib/go/"


### PR DESCRIPTION
Usage: `make DESTDIR=<dest_dir> install`

See https://github.com/google/grumpy/issues/210

* Mac OSX `install` does not accept the `-D` option
* Mac OSX `cp` does not accept the `--no-preserve=ownership` option