### PR TITLE
Specalize NewTuple to support 0 to 6 direct arguments.

### DIFF
--- a/compiler/expr_visitor.py
+++ b/compiler/expr_visitor.py
@@ -17,6 +17,7 @@
 """Visitor class for traversing Python expressions."""
 
 import ast
+import contextlib
 import textwrap
 
 from grumpy.compiler import block
@@ -188,14 +189,19 @@ class ExprVisitor(ast.NodeVisitor):
 
   def visit_ExtSlice(self, node):
     result = self.block.alloc_temp()
-    with self.block.alloc_temp('[]*πg.Object') as dims:
-      self.writer.write('{} = make([]*πg.Object, {})'.format(
-          dims.name, len(node.dims)))
-      for i, dim in enumerate(node.dims):
-        with self.visit(dim) as s:
-          self.writer.write('{}[{}] = {}'.format(dims.name, i, s.expr))
-      self.writer.write('{} = πg.NewTuple({}...).ToObject()'.format(
-          result.name, dims.expr))
+    if len(node.dims) <= util.MAX_DIRECT_TUPLE:
+      with contextlib.nested(*(self.visit(d) for d in node.dims)) as dims:
+        self.writer.write('{} = πg.NewTuple{}({}).ToObject()'.format(
+            result.name, len(dims), ', '.join(d.expr for d in dims)))
+    else:
+      with self.block.alloc_temp('[]*πg.Object') as dims:
+        self.writer.write('{} = make([]*πg.Object, {})'.format(
+            dims.name, len(node.dims)))
+        for i, dim in enumerate(node.dims):
+          with self.visit(dim) as s:
+            self.writer.write('{}[{}] = {}'.format(dims.name, i, s.expr))
+        self.writer.write('{} = πg.NewTuple({}...).ToObject()'.format(
+            result.name, dims.expr))
     return result
 
   def visit_GeneratorExp(self, node):
@@ -313,10 +319,15 @@ class ExprVisitor(ast.NodeVisitor):
     return expr.GeneratedLiteral(expr_str)
 
   def visit_Tuple(self, node):
-    with self._visit_seq_elts(node.elts) as elems:
-      result = self.block.alloc_temp()
-      self.writer.write('{} = πg.NewTuple({}...).ToObject()'.format(
-          result.expr, elems.expr))
+    result = self.block.alloc_temp()
+    if len(node.elts) <= util.MAX_DIRECT_TUPLE:
+      with contextlib.nested(*(self.visit(e) for e in node.elts)) as elts:
+        self.writer.write('{} = πg.NewTuple{}({}).ToObject()'.format(
+            result.name, len(elts), ', '.join(e.expr for e in elts)))
+    else:
+      with self._visit_seq_elts(node.elts) as elems:
+        self.writer.write('{} = πg.NewTuple({}...).ToObject()'.format(
+            result.expr, elems.expr))
     return result
 
   def visit_UnaryOp(self, node):

--- a/compiler/util.py
+++ b/compiler/util.py
@@ -26,6 +26,12 @@ _SIMPLE_CHARS = set(string.digits + string.letters + string.punctuation + " ")
 _ESCAPES = {'\t': r'\t', '\r': r'\r', '\n': r'\n', '"': r'\"', '\\': r'\\'}
 
 
+# This is the max length of a direct allocation tuple supported by the runtime.
+# This should match the number of specializations found in
+# runtime/tuple_direct.go.
+MAX_DIRECT_TUPLE = 6
+
+
 class ParseError(Exception):
 
   def __init__(self, node, msg):

--- a/runtime/dict.go
+++ b/runtime/dict.go
@@ -819,7 +819,7 @@ func dictItemIteratorNext(f *Frame, o *Object) (ret *Object, raised *BaseExcepti
 	if raised != nil {
 		return nil, raised
 	}
-	return NewTuple(entry.key, entry.value).ToObject(), nil
+	return NewTuple2(entry.key, entry.value).ToObject(), nil
 }
 
 func initDictItemIteratorType(map[string]*Object) {

--- a/runtime/float.go
+++ b/runtime/float.go
@@ -84,7 +84,7 @@ func floatGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkMethodArgs(f, "__getnewargs__", args, FloatType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func floatGT(f *Frame, v, w *Object) (*Object, *BaseException) {

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -282,7 +282,7 @@ func frameExcInfo(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) 
 	if tb != nil {
 		tbObj = tb.ToObject()
 	}
-	return NewTuple(excObj, tbObj).ToObject(), nil
+	return NewTuple2(excObj, tbObj).ToObject(), nil
 }
 
 func initFrameType(dict map[string]*Object) {

--- a/runtime/int.go
+++ b/runtime/int.go
@@ -102,7 +102,7 @@ func intGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkMethodArgs(f, "__getnewargs__", args, IntType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func intGT(f *Frame, v, w *Object) (*Object, *BaseException) {

--- a/runtime/long.go
+++ b/runtime/long.go
@@ -124,7 +124,7 @@ func longGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkMethodArgs(f, "__getnewargs__", args, LongType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func longGT(x, y *big.Int) bool {

--- a/runtime/object.go
+++ b/runtime/object.go
@@ -283,11 +283,11 @@ func objectReduceCommon(f *Frame, args Args) (*Object, *BaseException) {
 				return nil, raised
 			}
 		}
-		newArgs := NewTuple(t.ToObject(), basisType.ToObject(), state).ToObject()
+		newArgs := NewTuple3(t.ToObject(), basisType.ToObject(), state).ToObject()
 		if d := o.Dict(); d != nil {
-			return NewTuple(objectReconstructorFunc, newArgs, d.ToObject()).ToObject(), nil
+			return NewTuple3(objectReconstructorFunc, newArgs, d.ToObject()).ToObject(), nil
 		}
-		return NewTuple(objectReconstructorFunc, newArgs).ToObject(), nil
+		return NewTuple2(objectReconstructorFunc, newArgs).ToObject(), nil
 	}
 	newArgs := []*Object{t.ToObject()}
 	getNewArgsMethod, raised := GetAttr(f, o, NewStr("__getnewargs__"), None)
@@ -332,5 +332,5 @@ func objectReduceCommon(f *Frame, args Args) (*Object, *BaseException) {
 	if raised != nil {
 		return nil, raised
 	}
-	return NewTuple(newFunc, NewTuple(newArgs...).ToObject(), dict, listItems, dictItems).ToObject(), nil
+	return NewTuple5(newFunc, NewTuple(newArgs...).ToObject(), dict, listItems, dictItems).ToObject(), nil
 }

--- a/runtime/range.go
+++ b/runtime/range.go
@@ -103,7 +103,7 @@ func enumerateNext(f *Frame, o *Object) (ret *Object, raised *BaseException) {
 			raised = f.Raise(StopIterationType.ToObject(), nil, nil)
 			e.index = -1
 		} else {
-			ret = NewTuple(NewInt(e.index).ToObject(), item).ToObject()
+			ret = NewTuple2(NewInt(e.index).ToObject(), item).ToObject()
 			e.index++
 		}
 	}

--- a/runtime/slice.go
+++ b/runtime/slice.go
@@ -129,14 +129,14 @@ func sliceNew(f *Frame, t *Type, args Args, _ KWArgs) (*Object, *BaseException) 
 
 func sliceRepr(f *Frame, o *Object) (*Object, *BaseException) {
 	s := toSliceUnsafe(o)
-	elems := []*Object{None, s.stop, None}
+	elem0, elem1, elem2 := None, s.stop, None
 	if s.start != nil {
-		elems[0] = s.start
+		elem0 = s.start
 	}
 	if s.step != nil {
-		elems[2] = s.step
+		elem2 = s.step
 	}
-	r, raised := Repr(f, NewTuple(elems...).ToObject())
+	r, raised := Repr(f, NewTuple3(elem0, elem1, elem2).ToObject())
 	if raised != nil {
 		return nil, raised
 	}

--- a/runtime/str.go
+++ b/runtime/str.go
@@ -307,7 +307,7 @@ func strGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkMethodArgs(f, "__getnewargs__", args, StrType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func strGT(f *Frame, v, w *Object) (*Object, *BaseException) {
@@ -416,7 +416,7 @@ func strMod(f *Frame, v, w *Object) (*Object, *BaseException) {
 	case w.isInstance(TupleType):
 		return strInterpolate(f, s, toTupleUnsafe(w))
 	default:
-		return strInterpolate(f, s, NewTuple(w))
+		return strInterpolate(f, s, NewTuple1(w))
 	}
 }
 

--- a/runtime/tuple.go
+++ b/runtime/tuple.go
@@ -35,6 +35,105 @@ func NewTuple(elems ...*Object) *Tuple {
 	return &Tuple{Object: Object{typ: TupleType}, elems: elems}
 }
 
+// Below are direct allocation versions of small Tuples. Rather than performing
+// two allocations, one for the tuple object and one for the slice holding the
+// elements, we allocate both objects at the same time in one block of memory.
+// This both decreases the number of allocations overall as well as increases
+// memory locality for tuple data. Both of which *should* improve time to
+// allocate as well as read performance. The methods below are used by the
+// compiler to create fixed size tuples when the size is known ahead of time.
+//
+// The number of specializations below were chosen first to cover all the fixed
+// size tuple allocations in the runtime (currently 5), then filled out to
+// cover the whole memory size class (see golang/src/runtime/sizeclasses.go for
+// the table). On a 64bit system, a tuple of length 6 occupies 96 bytes - 48
+// bytes for the tuple object and 6*8 (48) bytes of pointers.
+//
+// If methods are added or removed, then the constant MAX_DIRECT_TUPLE in
+// compiler/util.py needs to be updated as well.
+
+// NewTuple0 returns the empty tuple. This is mostly provided for the
+// convenience of the compiler.
+func NewTuple0() *Tuple { return emptyTuple }
+
+// NewTuple1 returns a tuple of length 1 containing just elem0.
+func NewTuple1(elem0 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [1]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [1]*Object{elem0},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
+// NewTuple2 returns a tuple of length 2 containing just elem0 and elem1.
+func NewTuple2(elem0, elem1 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [2]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [2]*Object{elem0, elem1},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
+// NewTuple3 returns a tuple of length 3 containing elem0 to elem2.
+func NewTuple3(elem0, elem1, elem2 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [3]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [3]*Object{elem0, elem1, elem2},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
+// NewTuple4 returns a tuple of length 4 containing elem0 to elem3.
+func NewTuple4(elem0, elem1, elem2, elem3 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [4]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [4]*Object{elem0, elem1, elem2, elem3},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
+// NewTuple5 returns a tuple of length 5 containing elem0 to elem4.
+func NewTuple5(elem0, elem1, elem2, elem3, elem4 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [5]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [5]*Object{elem0, elem1, elem2, elem3, elem4},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
+// NewTuple6 returns a tuple of length 6 containing elem0 to elem5.
+func NewTuple6(elem0, elem1, elem2, elem3, elem4, elem5 *Object) *Tuple {
+	t := struct {
+		tuple Tuple
+		elems [6]*Object
+	}{
+		tuple: Tuple{Object: Object{typ: TupleType}},
+		elems: [6]*Object{elem0, elem1, elem2, elem3, elem4, elem5},
+	}
+	t.tuple.elems = t.elems[:]
+	return &t.tuple
+}
+
 func toTupleUnsafe(o *Object) *Tuple {
 	return (*Tuple)(o.toPointer())
 }
@@ -99,7 +198,7 @@ func tupleGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkMethodArgs(f, "__getnewargs__", args, TupleType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func tupleGT(f *Frame, v, w *Object) (*Object, *BaseException) {

--- a/runtime/unicode.go
+++ b/runtime/unicode.go
@@ -190,7 +190,7 @@ func unicodeGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) 
 	if raised := checkMethodArgs(f, "__getnewargs__", args, UnicodeType); raised != nil {
 		return nil, raised
 	}
-	return NewTuple(args[0]).ToObject(), nil
+	return NewTuple1(args[0]).ToObject(), nil
 }
 
 func unicodeGT(f *Frame, v, w *Object) (*Object, *BaseException) {


### PR DESCRIPTION
This eliminates an extra allocation for the backing array by storing it in the memory directly following the tuple itself.

In the micro benchmarks, the big impact is on the dict iter items implementation where 2-tuples are generated for every entry in the dict. The 6 element test seemed to have high variation when run, but the rest paints a reasonable picture.

```
name                       old time/op    new time/op    delta
DictIterItems/0-elements      518ns ± 0%     517ns ± 1%     ~     (p=0.540 n=4+5)
DictIterItems/1-elements      629ns ± 4%     577ns ± 0%   -8.24%  (p=0.008 n=5+5)
DictIterItems/2-elements      687ns ± 0%     646ns ± 0%   -5.97%  (p=0.016 n=4+5)
DictIterItems/3-elements      807ns ± 1%     720ns ± 1%  -10.83%  (p=0.008 n=5+5)
DictIterItems/4-elements      902ns ± 4%     779ns ± 0%  -13.61%  (p=0.008 n=5+5)
DictIterItems/5-elements     1.02µs ± 1%    0.87µs ± 2%  -15.04%  (p=0.008 n=5+5)
DictIterItems/6-elements     1.29µs ± 1%    1.21µs ±14%     ~     (p=0.151 n=5+5)
DictIterItems/7-elements     1.39µs ± 1%    1.20µs ± 2%  -13.55%  (p=0.008 n=5+5)
DictIterItems/8-elements     1.45µs ± 2%    1.28µs ± 2%  -11.94%  (p=0.008 n=5+5)

name                       old alloc/op   new alloc/op   delta
DictIterItems/0-elements       320B ± 0%      320B ± 0%     ~     (all equal)
DictIterItems/1-elements       384B ± 0%      384B ± 0%     ~     (all equal)
DictIterItems/2-elements       448B ± 0%      448B ± 0%     ~     (all equal)
DictIterItems/3-elements       512B ± 0%      512B ± 0%     ~     (all equal)
DictIterItems/4-elements       576B ± 0%      576B ± 0%     ~     (all equal)
DictIterItems/5-elements       640B ± 0%      640B ± 0%     ~     (all equal)
DictIterItems/6-elements       704B ± 0%      704B ± 0%     ~     (all equal)
DictIterItems/7-elements       768B ± 0%      768B ± 0%     ~     (all equal)
DictIterItems/8-elements       832B ± 0%      832B ± 0%     ~     (all equal)

name                       old allocs/op  new allocs/op  delta
DictIterItems/0-elements       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
DictIterItems/1-elements       8.00 ± 0%      7.00 ± 0%  -12.50%  (p=0.008 n=5+5)
DictIterItems/2-elements       10.0 ± 0%       8.0 ± 0%  -20.00%  (p=0.008 n=5+5)
DictIterItems/3-elements       12.0 ± 0%       9.0 ± 0%  -25.00%  (p=0.008 n=5+5)
DictIterItems/4-elements       14.0 ± 0%      10.0 ± 0%  -28.57%  (p=0.008 n=5+5)
DictIterItems/5-elements       16.0 ± 0%      11.0 ± 0%  -31.25%  (p=0.008 n=5+5)
DictIterItems/6-elements       18.0 ± 0%      12.0 ± 0%  -33.33%  (p=0.008 n=5+5)
DictIterItems/7-elements       20.0 ± 0%      13.0 ± 0%  -35.00%  (p=0.008 n=5+5)
DictIterItems/8-elements       22.0 ± 0%      14.0 ± 0%  -36.36%  (p=0.008 n=5+5)
```

The changes to the compiler do have an impact on the output code. In most cases, it actually reduces the number of temporary variables needed at any given time. While I doubt that will have any impact on the actual compiled output (given the coming SSA backend), less allocations should have an impact. I can try grabbing numbers if anyone thinks it would be interesting, but I'm not sure we have any good benchmarks which would be affected by this change.