### PR TITLE
Implement __hex__ and __oct__

### DIFF
--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -402,19 +402,7 @@ func builtinHex(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "hex", args, ObjectType); raised != nil {
 		return nil, raised
 	}
-	if method, raised := args[0].typ.mroLookup(f, NewStr("__hex__")); raised != nil {
-		return nil, raised
-	} else if method != nil {
-		return method.Call(f, args, nil)
-	}
-	if !args[0].isInstance(IntType) && !args[0].isInstance(LongType) {
-		return nil, f.RaiseType(TypeErrorType, "hex() argument can't be converted to hex")
-	}
-	s := numberToBase("0x", 16, args[0])
-	if args[0].isInstance(LongType) {
-		s += "L"
-	}
-	return NewStr(s).ToObject(), nil
+	return Hex(f, args[0])
 }
 
 func builtinID(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
@@ -491,23 +479,7 @@ func builtinOct(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 	if raised := checkFunctionArgs(f, "oct", args, ObjectType); raised != nil {
 		return nil, raised
 	}
-	if method, raised := args[0].typ.mroLookup(f, NewStr("__oct__")); raised != nil {
-		return nil, raised
-	} else if method != nil {
-		return method.Call(f, args, nil)
-	}
-	if !args[0].isInstance(IntType) && !args[0].isInstance(LongType) {
-		return nil, f.RaiseType(TypeErrorType, "oct() argument can't be converted to oct")
-	}
-	s := numberToBase("0", 8, args[0])
-	if args[0].isInstance(LongType) {
-		s += "L"
-	}
-	// For oct(0), return "0", not "00".
-	if s == "00" {
-		s = "0"
-	}
-	return NewStr(s).ToObject(), nil
+	return Oct(f, args[0])
 }
 
 func builtinOpen(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -257,14 +257,8 @@ func Hash(f *Frame, o *Object) (*Int, *BaseException) {
 func Hex(f *Frame, o *Object) (*Object, *BaseException) {
 	hex := o.typ.slots.Hex
 	if hex == nil {
-		if method, raised := o.typ.mroLookup(f, NewStr("__hex__")); raised != nil {
-			return nil, raised
-		} else if method != nil {
-			return method.Call(f, nil, nil)
-		} else {
-			_, raised := hexNotImplemented(f, o)
-			return nil, raised
-		}
+		raised := f.RaiseType(TypeErrorType, "hex() argument can't be converted to hex")
+		return nil, raised
 	}
 	h, raised := hex.Fn(f, o)
 	if raised != nil {
@@ -623,14 +617,8 @@ func Next(f *Frame, iter *Object) (*Object, *BaseException) {
 func Oct(f *Frame, o *Object) (*Object, *BaseException) {
 	oct := o.typ.slots.Oct
 	if oct == nil {
-		if method, raised := o.typ.mroLookup(f, NewStr("__oct__")); raised != nil {
-			return nil, raised
-		} else if method != nil {
-			return method.Call(f, nil, nil)
-		} else {
-			_, raised := octNotImplemented(f, o)
-			return nil, raised
-		}
+		raised := f.RaiseType(TypeErrorType, "oct() argument can't be converted to oct")
+		return nil, raised
 	}
 	o, raised := oct.Fn(f, o)
 	if raised != nil {
@@ -1225,14 +1213,6 @@ func checkMethodVarArgs(f *Frame, method string, args Args, types ...*Type) *Bas
 
 func hashNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
 	return nil, f.RaiseType(TypeErrorType, fmt.Sprintf("unhashable type: '%s'", o.typ.Name()))
-}
-
-func hexNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
-	return nil, f.RaiseType(TypeErrorType, "hex() argument can't be converted to hex")
-}
-
-func octNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
-	return nil, f.RaiseType(TypeErrorType, "oct() argument can't be converted to oct")
 }
 
 // pyPrint encapsulates the logic of the Python print function.

--- a/runtime/int.go
+++ b/runtime/int.go
@@ -118,6 +118,11 @@ func intHash(f *Frame, o *Object) (*Object, *BaseException) {
 	return o, nil
 }
 
+func intHex(f *Frame, o *Object) (*Object, *BaseException) {
+	val := numberToBase("0x", 16, o)
+	return NewStr(val).ToObject(), nil
+}
+
 func intIndex(f *Frame, o *Object) (*Object, *BaseException) {
 	return o, nil
 }
@@ -244,6 +249,14 @@ func intNonZero(f *Frame, o *Object) (*Object, *BaseException) {
 	return GetBool(toIntUnsafe(o).Value() != 0).ToObject(), nil
 }
 
+func intOct(f *Frame, o *Object) (*Object, *BaseException) {
+	val := numberToBase("0", 8, o)
+	if val == "00" {
+		val = "0"
+	}
+	return NewStr(val).ToObject(), nil
+}
+
 func intOr(f *Frame, v, w *Object) (*Object, *BaseException) {
 	if !w.isInstance(IntType) {
 		return NotImplemented, nil
@@ -358,6 +371,7 @@ func initIntType(dict map[string]*Object) {
 	IntType.slots.GT = &binaryOpSlot{intGT}
 	IntType.slots.Float = &unaryOpSlot{intFloat}
 	IntType.slots.Hash = &unaryOpSlot{intHash}
+	IntType.slots.Hex = &unaryOpSlot{intHex}
 	IntType.slots.Index = &unaryOpSlot{intIndex}
 	IntType.slots.Int = &unaryOpSlot{intInt}
 	IntType.slots.Invert = &unaryOpSlot{intInvert}
@@ -372,6 +386,7 @@ func initIntType(dict map[string]*Object) {
 	IntType.slots.Neg = &unaryOpSlot{intNeg}
 	IntType.slots.New = &newSlot{intNew}
 	IntType.slots.NonZero = &unaryOpSlot{intNonZero}
+	IntType.slots.Oct = &unaryOpSlot{intOct}
 	IntType.slots.Or = &binaryOpSlot{intOr}
 	IntType.slots.Pow = &binaryOpSlot{intPow}
 	IntType.slots.RAdd = &binaryOpSlot{intRAdd}

--- a/runtime/long.go
+++ b/runtime/long.go
@@ -144,6 +144,11 @@ func hashBigInt(x *big.Int) int {
 	return hashString(x.Text(36))
 }
 
+func longHex(f *Frame, o *Object) (*Object, *BaseException) {
+	val := numberToBase("0x", 16, o) + "L"
+	return NewStr(val).ToObject(), nil
+}
+
 func longHash(f *Frame, o *Object) (*Object, *BaseException) {
 	l := toLongUnsafe(o)
 	l.hashOnce.Do(func() {
@@ -290,6 +295,14 @@ func longNonZero(x *big.Int) bool {
 	return x.Sign() != 0
 }
 
+func longOct(f *Frame, o *Object) (*Object, *BaseException) {
+	val := numberToBase("0", 8, o) + "L"
+	if val == "00L" {
+		val = "0L"
+	}
+	return NewStr(val).ToObject(), nil
+}
+
 func longOr(z, x, y *big.Int) {
 	z.Or(x, y)
 }
@@ -325,6 +338,7 @@ func initLongType(dict map[string]*Object) {
 	LongType.slots.GE = longBinaryBoolOpSlot(longGE)
 	LongType.slots.GT = longBinaryBoolOpSlot(longGT)
 	LongType.slots.Hash = &unaryOpSlot{longHash}
+	LongType.slots.Hex = &unaryOpSlot{longHex}
 	LongType.slots.Index = &unaryOpSlot{longIndex}
 	LongType.slots.Int = &unaryOpSlot{longInt}
 	LongType.slots.Invert = longUnaryOpSlot(longInvert)
@@ -339,6 +353,7 @@ func initLongType(dict map[string]*Object) {
 	LongType.slots.Neg = longUnaryOpSlot(longNeg)
 	LongType.slots.New = &newSlot{longNew}
 	LongType.slots.NonZero = longUnaryBoolOpSlot(longNonZero)
+	LongType.slots.Oct = &unaryOpSlot{longOct}
 	LongType.slots.Or = longBinaryOpSlot(longOr)
 	// This operation can return a float, it must use binaryOpSlot directly.
 	LongType.slots.Pow = &binaryOpSlot{longPow}

--- a/runtime/slots.go
+++ b/runtime/slots.go
@@ -388,6 +388,7 @@ type typeSlots struct {
 	GetItem      *binaryOpSlot
 	GT           *binaryOpSlot
 	Hash         *unaryOpSlot
+	Hex          *unaryOpSlot
 	IAdd         *binaryOpSlot
 	IAnd         *binaryOpSlot
 	IDiv         *binaryOpSlot
@@ -415,6 +416,7 @@ type typeSlots struct {
 	New          *newSlot
 	Next         *unaryOpSlot
 	NonZero      *unaryOpSlot
+	Oct          *unaryOpSlot
 	Or           *binaryOpSlot
 	Pow          *binaryOpSlot
 	RAdd         *binaryOpSlot


### PR DESCRIPTION
* Implement default `__hex__` and `__oct__` for `int` and `long`
* Refactor builtin `hex` and `oct`.

Signed-off-by: choleraehyq <choleraehyq@gmail.com>