### PR TITLE
Switch pyPrint() into based on *grumpy.File

### DIFF
--- a/lib/sys.py
+++ b/lib/sys.py
@@ -14,8 +14,8 @@
 
 """System-specific parameters and functions."""
 
-from __go__.os import Args, Stdin, Stdout, Stderr
-from __go__.grumpy import SysModules, MaxInt, NewFileFromFD  # pylint: disable=g-multiple-import
+from __go__.os import Args
+from __go__.grumpy import SysModules, MaxInt, Stdin as stdin, Stdout as stdout, Stderr as stderr  # pylint: disable=g-multiple-import
 from __go__.runtime import Version
 from __go__.unicode import MaxRune
 
@@ -32,11 +32,6 @@ py3kwarning = False
 warnoptions = []
 # TODO: Support actual byteorder
 byteorder = 'little'
-
-stdin = NewFileFromFD(Stdin.Fd())
-stdout = NewFileFromFD(Stdout.Fd())
-stderr = NewFileFromFD(Stderr.Fd())
-
 
 class _Flags(object):
   """Container class for sys.flags."""

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"os"
 	"unicode"
 )
 
@@ -528,7 +527,7 @@ func builtinOrd(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 func builtinPrint(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	sep := " "
 	end := "\n"
-	file := os.Stdout
+	file := Stdout
 	for _, kwarg := range kwargs {
 		switch kwarg.Name {
 		case "sep":

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -350,10 +350,10 @@ func captureStdout(f *Frame, fn func() *BaseException) (string, *BaseException) 
 	if err != nil {
 		return "", f.RaiseType(RuntimeErrorType, fmt.Sprintf("failed to open pipe: %v", err))
 	}
-	oldStdout := os.Stdout
-	os.Stdout = w
+	oldStdout := Stdout
+	Stdout = NewFileFromFD(w.Fd())
 	defer func() {
-		os.Stdout = oldStdout
+		Stdout = oldStdout
 	}()
 	done := make(chan struct{})
 	var raised *BaseException

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -16,7 +16,6 @@ package grumpy
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"reflect"
@@ -641,7 +640,7 @@ func Print(f *Frame, args Args, nl bool) *BaseException {
 	} else if len(args) > 0 {
 		end = " "
 	}
-	return pyPrint(f, args, " ", end, os.Stdout)
+	return pyPrint(f, args, " ", end, Stdout)
 }
 
 // Repr returns a string containing a printable representation of o. This is
@@ -1216,17 +1215,17 @@ func hashNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
 }
 
 // pyPrint encapsulates the logic of the Python print function.
-func pyPrint(f *Frame, args Args, sep, end string, file io.Writer) *BaseException {
+func pyPrint(f *Frame, args Args, sep, end string, file *File) *BaseException {
 	for i, arg := range args {
 		if i > 0 {
-			fmt.Fprint(file, sep)
+			file.writeString(sep)
 		}
 		s, raised := ToStr(f, arg)
 		if raised != nil {
 			return raised
 		}
-		fmt.Fprint(file, s.Value())
+		file.writeString(s.Value())
 	}
-	fmt.Fprint(file, end)
+	file.writeString(end)
 	return nil
 }

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -1218,14 +1218,27 @@ func hashNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
 func pyPrint(f *Frame, args Args, sep, end string, file *File) *BaseException {
 	for i, arg := range args {
 		if i > 0 {
-			file.writeString(sep)
+			err := file.writeString(sep)
+			if err != nil {
+				return f.RaiseType(IOErrorType, err.Error())
+			}
 		}
+
 		s, raised := ToStr(f, arg)
 		if raised != nil {
 			return raised
 		}
-		file.writeString(s.Value())
+
+		err := file.writeString(s.Value())
+		if err != nil {
+			return f.RaiseType(IOErrorType, err.Error())
+		}
 	}
-	file.writeString(end)
+
+	err := file.writeString(end)
+	if err != nil {
+		return f.RaiseType(IOErrorType, err.Error())
+	}
+
 	return nil
 }

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -15,7 +15,6 @@
 package grumpy
 
 import (
-	"bytes"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -790,12 +789,9 @@ func TestOct(t *testing.T) {
 
 func TestPyPrint(t *testing.T) {
 	fun := wrapFuncForTest(func(f *Frame, args *Tuple, sep, end string) (string, *BaseException) {
-		var buf bytes.Buffer
-		raised := pyPrint(NewRootFrame(), args.elems, sep, end, &buf)
-		if raised != nil {
-			return "", raised
-		}
-		return buf.String(), nil
+		return captureStdout(f, func() *BaseException {
+			return pyPrint(NewRootFrame(), args.elems, sep, end, Stdout)
+		})
 	})
 	cases := []invokeTestCase{
 		{args: wrapArgs(NewTuple(), "", "\n"), want: NewStr("\n").ToObject()},

--- a/runtime/file.go
+++ b/runtime/file.go
@@ -89,6 +89,19 @@ func (f *File) readLine(maxBytes int) (string, error) {
 	return buf.String(), nil
 }
 
+func (f *File) writeString(s string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	if !f.open {
+		return io.ErrClosedPipe
+	}
+	if _, err := f.file.Write([]byte(s)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // FileType is the object representing the Python 'file' type.
 var FileType = newBasisType("file", reflect.TypeOf(File{}), toFileUnsafe, ObjectType)
 
@@ -342,3 +355,12 @@ func fileParseReadArgs(f *Frame, method string, args Args) (*File, int, *BaseExc
 	}
 	return toFileUnsafe(args[0]), size, nil
 }
+
+var (
+	// Stdin is an alias for sys.stdin.
+	Stdin = NewFileFromFD(os.Stdin.Fd())
+	// Stdout is an alias for sys.stdout.
+	Stdout = NewFileFromFD(os.Stdout.Fd())
+	// Stderr is an aliaas for sys.stderr.
+	Stderr = NewFileFromFD(os.Stderr.Fd())
+)


### PR DESCRIPTION
This PR is changing pyPirnt() into based on *grumpy.File.
It is related to PR #233 which is discussions about Stdout and Stdin.
I will proceed PR #233 after this PR is merged.

Related PR= #233