### PR TITLE
Fix unsafe cast caused by dictNE checking the type of wrong arg

### DIFF
--- a/runtime/dict.go
+++ b/runtime/dict.go
@@ -705,7 +705,7 @@ func dictLen(f *Frame, o *Object) (*Object, *BaseException) {
 }
 
 func dictNE(f *Frame, v, w *Object) (*Object, *BaseException) {
-	if !v.isInstance(DictType) {
+	if !w.isInstance(DictType) {
 		return NotImplemented, nil
 	}
 	eq, raised := dictsAreEqual(f, toDictUnsafe(v), toDictUnsafe(w))


### PR DESCRIPTION
This fixes https://github.com/google/grumpy/issues/251

dictNE was checking v.isInstance(DictType) instead of checking w. This
causes a variety of undefined behavior including segfault, invalid mutex
state, etc.