### PR TITLE
Update mktime to return local time result, not utc

### DIFF
--- a/lib/time.py
+++ b/lib/time.py
@@ -14,7 +14,7 @@
 
 """Time access and conversions."""
 
-from __go__.time import Now, Second, Sleep, Unix, Date, UTC # pylint: disable=g-multiple-import
+from __go__.time import Local, Now, Second, Sleep, Unix, Date, UTC # pylint: disable=g-multiple-import
 
 
 _strftime_directive_map = {
@@ -81,7 +81,7 @@ def localtime(seconds=None):
 
 
 def mktime(t):
-  return float(Date(t[0], t[1], t[2], t[3], t[4], t[5], 0, UTC).Unix())
+  return float(Date(t[0], t[1], t[2], t[3], t[4], t[5], 0, Local).Unix())
 
 
 def sleep(secs):
@@ -93,7 +93,7 @@ def time():
 
 
 def strftime(format, tt=None):  # pylint: disable=missing-docstring,redefined-builtin
-  t = (Unix(int(mktime(tt)), 0) if tt else Now()).Local()
+  t = Unix(int(mktime(tt)), 0) if tt else Now()
   ret = []
   prev, n = 0, format.find('%', 0, -1)
   while n != -1:

--- a/lib/time_test.py
+++ b/lib/time_test.py
@@ -16,3 +16,7 @@ import time
 
 assert time.time() > 1000000000
 assert time.time() < 3000000000
+
+time_struct = (1999, 9, 19, 0, 0, 0, 6, 262, 0)
+got = time.localtime(time.mktime(time_struct))
+assert got == time_struct, got


### PR DESCRIPTION
Per the docs, mktime expects a time struct in local time, not UTC:
https://docs.python.org/2/library/time.html#time.mktime

This mismatch was causing TestDate.test_fromtimestamp in
test_datetime.py to fail on some systems.