### PR TITLE
Implemented float.__hash__().

### DIFF
--- a/runtime/float.go
+++ b/runtime/float.go
@@ -20,6 +20,7 @@ import (
 	"math/big"
 	"reflect"
 	"strconv"
+	"sync"
 )
 
 // FloatType is the object representing the Python 'float' type.
@@ -28,12 +29,16 @@ var FloatType = newBasisType("float", reflect.TypeOf(Float{}), toFloatUnsafe, Ob
 // Float represents Python 'float' objects.
 type Float struct {
 	Object
-	value float64
+	value    float64
+	hashOnce sync.Once
+	hash     int
 }
 
 // NewFloat returns a new Float holding the given floating point value.
 func NewFloat(value float64) *Float {
-	return &Float{Object{typ: FloatType}, value}
+	result := Float{Object: Object{typ: FloatType}}
+	result.value = value
+	return &result
 }
 
 func toFloatUnsafe(o *Object) *Float {
@@ -89,6 +94,19 @@ func floatGetNewArgs(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
 
 func floatGT(f *Frame, v, w *Object) (*Object, *BaseException) {
 	return floatCompare(toFloatUnsafe(v), w, False, False, True), nil
+}
+
+func floatHash(f *Frame, o *Object) (*Object, *BaseException) {
+	v := toFloatUnsafe(o)
+	v.hashOnce.Do(func() {
+		hash := hashFloat(v.Value())
+		if hash == -1 {
+			hash--
+		}
+		v.hash = hash
+	})
+
+	return NewInt(v.hash).ToObject(), nil
 }
 
 func floatInt(f *Frame, o *Object) (*Object, *BaseException) {
@@ -250,6 +268,7 @@ func initFloatType(dict map[string]*Object) {
 	FloatType.slots.Float = &unaryOpSlot{floatFloat}
 	FloatType.slots.GE = &binaryOpSlot{floatGE}
 	FloatType.slots.GT = &binaryOpSlot{floatGT}
+	FloatType.slots.Hash = &unaryOpSlot{floatHash}
 	FloatType.slots.Int = &unaryOpSlot{floatInt}
 	FloatType.slots.Long = &unaryOpSlot{floatLong}
 	FloatType.slots.LE = &binaryOpSlot{floatLE}
@@ -353,6 +372,39 @@ func floatDivModOp(f *Frame, method string, v, w *Object, fun func(v, w float64)
 		return nil, f.RaiseType(ZeroDivisionErrorType, "float division or modulo by zero")
 	}
 	return NewFloat(x).ToObject(), nil
+}
+
+func hashFloat(v float64) int {
+	if math.IsNaN(v) {
+		return 0
+	}
+
+	if math.IsInf(v, 0) {
+		if math.IsInf(v, 1) {
+			return 314159
+		} else if math.IsInf(v, -1) {
+			return -271828
+		} else {
+			return 0
+		}
+	} else {
+		_, fracPart := math.Modf(v)
+		if fracPart == 0.0 {
+			i := big.Int{}
+			big.NewFloat(v).Int(&i)
+			if numInIntRange(&i) {
+				return int(i.Int64())
+			}
+			// TODO: hashBigInt() is not yet matched that of cpython or pypy.
+			return hashBigInt(&i)
+		}
+	}
+	v, expo := math.Frexp(v)
+	v *= 2147483648.0
+	hiPart := int(v)
+	v = (v - float64(hiPart)) * 2147483648.0
+	x := int(hiPart + int(v) + (expo << 15))
+	return x
 }
 
 func floatModFunc(v, w float64) (float64, bool) {

--- a/runtime/float_test.go
+++ b/runtime/float_test.go
@@ -151,6 +151,22 @@ func TestFloatLong(t *testing.T) {
 	}
 }
 
+func TestFloatHash(t *testing.T) {
+	cases := []invokeTestCase{
+		{args: wrapArgs(NewFloat(0.0)), want: NewInt(0).ToObject()},
+		{args: wrapArgs(NewFloat(3.14)), want: NewInt(3146129223).ToObject()},
+		{args: wrapArgs(NewFloat(42.0)), want: NewInt(42).ToObject()},
+		{args: wrapArgs(NewFloat(42.125)), want: NewInt(1413677056).ToObject()},
+		{args: wrapArgs(NewFloat(math.Inf(1))), want: NewInt(314159).ToObject()},
+		{args: wrapArgs(NewFloat(math.Inf(-1))), want: NewInt(-271828).ToObject()},
+		{args: wrapArgs(NewFloat(math.NaN())), want: NewInt(0).ToObject()},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(wrapFuncForTest(floatHash), &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}
 func TestFloatIsTrue(t *testing.T) {
 	cases := []invokeTestCase{
 		{args: wrapArgs(0.0), want: False.ToObject()},
@@ -167,6 +183,11 @@ func TestFloatIsTrue(t *testing.T) {
 func TestFloatNew(t *testing.T) {
 	floatNew := mustNotRaise(GetAttr(NewRootFrame(), FloatType.ToObject(), NewStr("__new__"), nil))
 	strictEqType := newTestClassStrictEq("StrictEq", FloatType)
+	newStrictEq := func(v float64) *Object {
+		f := Float{Object: Object{typ: strictEqType}}
+		f.value = v
+		return f.ToObject()
+	}
 	subType := newTestClass("SubType", []*Type{FloatType}, newStringDict(map[string]*Object{}))
 	subTypeObject := (&Float{Object: Object{typ: subType}, value: 3.14}).ToObject()
 	goodSlotType := newTestClass("GoodSlot", []*Type{ObjectType}, newStringDict(map[string]*Object{
@@ -203,8 +224,8 @@ func TestFloatNew(t *testing.T) {
 		{args: wrapArgs(FloatType, newObject(goodSlotType)), want: NewFloat(3.14).ToObject()},
 		{args: wrapArgs(FloatType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__float__ returned non-float (type object)")},
 		{args: wrapArgs(FloatType, newObject(slotSubTypeType)), want: subTypeObject},
-		{args: wrapArgs(strictEqType, 3.14), want: (&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
-		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: (&Float{Object{typ: strictEqType}, 3.14}).ToObject()},
+		{args: wrapArgs(strictEqType, 3.14), want: newStrictEq(3.14)},
+		{args: wrapArgs(strictEqType, newObject(goodSlotType)), want: newStrictEq(3.14)},
 		{args: wrapArgs(strictEqType, newObject(badSlotType)), wantExc: mustCreateException(TypeErrorType, "__float__ returned non-float (type object)")},
 		{args: wrapArgs(), wantExc: mustCreateException(TypeErrorType, "'__new__' requires 1 arguments")},
 		{args: wrapArgs(IntType), wantExc: mustCreateException(TypeErrorType, "float.__new__(int): int is not a subtype of float")},

--- a/runtime/float_test.go
+++ b/runtime/float_test.go
@@ -184,8 +184,7 @@ func TestFloatNew(t *testing.T) {
 	floatNew := mustNotRaise(GetAttr(NewRootFrame(), FloatType.ToObject(), NewStr("__new__"), nil))
 	strictEqType := newTestClassStrictEq("StrictEq", FloatType)
 	newStrictEq := func(v float64) *Object {
-		f := Float{Object: Object{typ: strictEqType}}
-		f.value = v
+		f := Float{Object: Object{typ: strictEqType}, value: v}
 		return f.ToObject()
 	}
 	subType := newTestClass("SubType", []*Type{FloatType}, newStringDict(map[string]*Object{}))

--- a/runtime/set_test.go
+++ b/runtime/set_test.go
@@ -184,10 +184,10 @@ func TestSetIter(t *testing.T) {
 	cases := []invokeTestCase{
 		{args: wrapArgs(NewSet()), want: NewTuple().ToObject()},
 		{args: wrapArgs(newTestSet(1, 2, 3)), want: newTestTuple(1, 2, 3).ToObject()},
-		{args: wrapArgs(newTestSet("foo", 3.14)), want: newTestTuple(3.14, "foo").ToObject()},
+		{args: wrapArgs(newTestSet("foo", 3.14)), want: newTestTuple("foo", 3.14).ToObject()},
 		{args: wrapArgs(newTestFrozenSet()), want: NewTuple().ToObject()},
 		{args: wrapArgs(newTestFrozenSet(1, 2, 3)), want: newTestTuple(1, 2, 3).ToObject()},
-		{args: wrapArgs(newTestFrozenSet("foo", 3.14)), want: newTestTuple(3.14, "foo").ToObject()},
+		{args: wrapArgs(newTestFrozenSet("foo", 3.14)), want: newTestTuple("foo", 3.14).ToObject()},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(fun, &cas); err != "" {


### PR DESCRIPTION
For Implementing float.__hash__(), I referenced CPython and pypy implementations.
By implemented float hash, ordering of set and frozen set's elements between float type elements and other types elements are changed.


