### PR TITLE
fix for #17

### DIFF
--- a/compiler/block_test.py
+++ b/compiler/block_test.py
@@ -26,6 +26,9 @@ from grumpy.compiler import imputil
 from grumpy.compiler import util
 from grumpy import pythonparser
 
+from compiler.block import Var
+
+
 class PackageTest(unittest.TestCase):
 
   def testCreate(self):
@@ -224,6 +227,13 @@ class FunctionBlockVisitorTest(unittest.TestCase):
     self.assertEqual(sorted(visitor.vars.keys()), ['foo'])
     self.assertRegexpMatches(visitor.vars['foo'].init_expr, r'UnboundLocal')
 
+  def testTupleArgs(self):
+    func = _ParseStmt('def foo((bar, baz)): pass')
+    visitor = block.FunctionBlockVisitor(func)
+    self.assertEqual(len(visitor.vars), 3)
+    self.assertTrue(len([v for v in visitor.vars if visitor.vars[v].type == Var.TYPE_TUPLE_PARAM]), 1)
+    self.assertIn('bar', visitor.vars)
+    self.assertIn('baz', visitor.vars)
 
 def _MakeModuleBlock():
   importer = imputil.Importer(None, '__main__', '/tmp/foo.py', False)

--- a/compiler/block_test.py
+++ b/compiler/block_test.py
@@ -26,8 +26,6 @@ from grumpy.compiler import imputil
 from grumpy.compiler import util
 from grumpy import pythonparser
 
-from compiler.block import Var
-
 
 class PackageTest(unittest.TestCase):
 
@@ -231,7 +229,7 @@ class FunctionBlockVisitorTest(unittest.TestCase):
     func = _ParseStmt('def foo((bar, baz)): pass')
     visitor = block.FunctionBlockVisitor(func)
     self.assertEqual(len(visitor.vars), 3)
-    self.assertTrue(len([v for v in visitor.vars if visitor.vars[v].type == Var.TYPE_TUPLE_PARAM]), 1)
+    self.assertEqual(len([v for v in visitor.vars if visitor.vars[v].type == block.Var.TYPE_TUPLE_PARAM]), 2)
     self.assertIn('bar', visitor.vars)
     self.assertIn('baz', visitor.vars)
 

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -509,7 +509,7 @@ class StatementVisitor(algorithm.Visitor):
       if isinstance(arg, ast.Tuple):
         arg_name = 'τ{}'.format(id(arg.elts))
         with visitor.writer.indent_block():
-          visitor._tie_target(arg, util.adjust_local_name(arg_name))
+          visitor._tie_target(arg, util.adjust_local_name(arg_name))  # pylint: disable=protected-access
 
     # Indent so that the function body is aligned with the goto labels.
     with visitor.writer.indent_block():

--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -504,6 +504,13 @@ class StatementVisitor(algorithm.Visitor):
     func_block = block.FunctionBlock(self.block, node.name, func_visitor.vars,
                                      func_visitor.is_generator)
     visitor = StatementVisitor(func_block, self.future_node)
+
+    for arg in node.args.args:
+      if isinstance(arg, ast.Tuple):
+        arg_name = 'τ{}'.format(id(arg.elts))
+        with visitor.writer.indent_block():
+          visitor._tie_target(arg, util.adjust_local_name(arg_name))
+
     # Indent so that the function body is aligned with the goto labels.
     with visitor.writer.indent_block():
       visitor._visit_each(node.body)  # pylint: disable=protected-access
@@ -519,9 +526,13 @@ class StatementVisitor(algorithm.Visitor):
       defaults = [None] * (argc - len(args.defaults)) + args.defaults
       for i, (a, d) in enumerate(zip(args.args, defaults)):
         with self.visit_expr(d) if d else expr.nil_expr as default:
+          if isinstance(a, ast.Tuple):
+            name = util.go_str('τ{}'.format(id(a.elts)))
+          else:
+            name = util.go_str(a.arg)
           tmpl = '$args[$i] = πg.Param{Name: $name, Def: $default}'
           self.writer.write_tmpl(tmpl, args=func_args.expr, i=i,
-                                 name=util.go_str(a.arg), default=default.expr)
+                                 name=name, default=default.expr)
       flags = []
       if args.vararg:
         flags.append('πg.CodeFlagVarArg')
@@ -583,6 +594,8 @@ class StatementVisitor(algorithm.Visitor):
   def _assign_target(self, target, value):
     if isinstance(target, ast.Name):
       self.block.bind_var(self.writer, target.id, value)
+    elif isinstance(target, ast.arg):
+      self.block.bind_var(self.writer, target.arg, value)
     elif isinstance(target, ast.Attribute):
       with self.visit_expr(target.value) as obj:
         self.writer.write_checked_call1(

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -243,6 +243,30 @@ class StatementVisitorTest(unittest.TestCase):
           print a, b
         foo('bar', 'baz')""")))
 
+  def testFunctionDefWithTupleArgs(self):
+    self.assertEqual((0, "('bar', 'baz')\n"), _GrumpRun(textwrap.dedent("""\
+        def foo((a, b)):
+          print(a, b)
+        foo(('bar', 'baz'))""")))
+
+  def testFunctionDefWithNestedTupleArgs(self):
+    self.assertEqual((0, "('bar', 'baz', 'qux')\n"), _GrumpRun(textwrap.dedent("""\
+        def foo(((a, b), c)):
+          print(a, b, c)
+        foo((('bar', 'baz'), 'qux'))""")))
+
+  def testFunctionDefWithMultipleTupleArgs(self):
+    self.assertEqual((0, "('bar', 'baz')\n"), _GrumpRun(textwrap.dedent("""\
+        def foo(((a, ), (b, ))):
+          print(a, b)
+        foo((('bar',), ('baz', )))""")))
+
+  def testFunctionDefTupleArgsInLambda(self):
+    self.assertEqual((0, "[(3, 2), (4, 3), (12, 1)]\n"), _GrumpRun(textwrap.dedent("""\
+        c = {12: 1, 3: 2, 4: 3}
+        top = sorted(c.items(), key=lambda (k,v): v)
+        print (top)""")))
+
   def testFunctionDefGenerator(self):
     self.assertEqual((0, "['foo', 'bar']\n"), _GrumpRun(textwrap.dedent("""\
         def gen():


### PR DESCRIPTION
This is something which I could come up with in a couple of hours. The idea is to merge the constituent tuple arguments into a single argument (by joining argument names with τ) and get them unpacked inside the function using array notation.

Let me know your thoughts on the same. Unit tests are still work in progress; will update the PR once they are ready!