### PR TITLE
Importer class that subsumes ImportVisitor & Path

### DIFF
--- a/compiler/block.py
+++ b/compiler/block.py
@@ -150,9 +150,10 @@ class ModuleBlock(Block):
     imports: A dict mapping fully qualified Go package names to Package objects.
   """
 
-  def __init__(self, path, full_package_name, filename, src, future_features):
+  def __init__(self, importer, full_package_name,
+               filename, src, future_features):
     Block.__init__(self, None, '<module>')
-    self.path = path
+    self.importer = importer
     self.full_package_name = full_package_name
     self.filename = filename
     self.buffer = source.Buffer(src)

--- a/compiler/block_test.py
+++ b/compiler/block_test.py
@@ -25,7 +25,6 @@ import pythonparser
 
 from grumpy.compiler import block
 from grumpy.compiler import imputil
-from grumpy.compiler import imputil_test
 from grumpy.compiler import util
 
 class PackageTest(unittest.TestCase):
@@ -247,8 +246,9 @@ class FunctionBlockVisitorTest(unittest.TestCase):
 
 
 def _MakeModuleBlock():
-  return block.ModuleBlock(imputil_test.MockPath(), '__main__',
-                           '<test>', '', imputil.FutureFeatures())
+  importer = imputil.Importer(None, '__main__', '/tmp/foo.py', False)
+  return block.ModuleBlock(importer, '__main__', '<test>', '',
+                           imputil.FutureFeatures())
 
 
 def _ParseStmt(stmt_str):

--- a/compiler/expr_visitor_test.py
+++ b/compiler/expr_visitor_test.py
@@ -26,7 +26,6 @@ import pythonparser
 
 from grumpy.compiler import block
 from grumpy.compiler import imputil
-from grumpy.compiler import imputil_test
 from grumpy.compiler import shard_test
 from grumpy.compiler import stmt
 
@@ -222,9 +221,10 @@ class ExprVisitorTest(unittest.TestCase):
   testUnaryOpInvert = _MakeExprTest('~4')
   testUnaryOpPos = _MakeExprTest('+4')
 
+
 def _MakeModuleBlock():
-  return block.ModuleBlock(imputil_test.MockPath(), '__main__',
-                           '<test>', '', imputil.FutureFeatures())
+  return block.ModuleBlock(None, '__main__', '<test>', '',
+                           imputil.FutureFeatures())
 
 
 def _ParseExpr(expr):

--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -28,7 +28,6 @@ from pythonparser import ast
 
 from grumpy.compiler import block
 from grumpy.compiler import imputil
-from grumpy.compiler import imputil_test
 from grumpy.compiler import shard_test
 from grumpy.compiler import stmt
 from grumpy.compiler import util
@@ -532,15 +531,16 @@ class StatementVisitorTest(unittest.TestCase):
 
 
 def _MakeModuleBlock():
-  return block.ModuleBlock(imputil_test.MockPath(), '__main__',
-                           '<test>', '', imputil.FutureFeatures())
+  return block.ModuleBlock(None, '__main__', '<test>', '',
+                           imputil.FutureFeatures())
 
 
 def _ParseAndVisit(source):
   mod = pythonparser.parse(source)
   _, future_features = imputil.parse_future_features(mod)
-  b = block.ModuleBlock(imputil_test.MockPath(), '__main__',
-                        '<test>', source, future_features)
+  importer = imputil.Importer(None, 'foo', 'foo.py', False)
+  b = block.ModuleBlock(importer, '__main__', '<test>',
+                        source, future_features)
   visitor = stmt.StatementVisitor(b)
   visitor.visit(mod)
   return visitor

--- a/compiler/util_test.py
+++ b/compiler/util_test.py
@@ -22,7 +22,6 @@ import unittest
 
 from grumpy.compiler import block
 from grumpy.compiler import imputil
-from grumpy.compiler import imputil_test
 from grumpy.compiler import util
 
 
@@ -38,8 +37,8 @@ class WriterTest(unittest.TestCase):
 
   def testWriteBlock(self):
     writer = util.Writer()
-    mod_block = block.ModuleBlock(imputil_test.MockPath(), '__main__',
-                                  '<test>', '', imputil.FutureFeatures())
+    mod_block = block.ModuleBlock(None, '__main__', '<test>', '',
+                                  imputil.FutureFeatures())
     writer.write_block(mod_block, 'BODY')
     output = writer.getvalue()
     dispatch = 'switch πF.State() {\n\tcase 0:\n\tdefault: panic'

--- a/tools/grumpc
+++ b/tools/grumpc
@@ -64,10 +64,10 @@ def main(args):
     print >> sys.stderr, str(e)
     return 2
 
-  path = imputil.Path(gopath, args.modname, args.script,
-                      future_features.absolute_import)
+  importer = imputil.Importer(gopath, args.modname, args.script,
+                              future_features.absolute_import)
   full_package_name = args.modname.replace('.', '/')
-  mod_block = block.ModuleBlock(path, full_package_name, args.script,
+  mod_block = block.ModuleBlock(importer, full_package_name, args.script,
                                 py_contents, future_features)
   mod_block.add_native_import('grumpy')
   visitor = stmt.StatementVisitor(mod_block, future_node)

--- a/tools/pydeps
+++ b/tools/pydeps
@@ -21,6 +21,7 @@ import os
 import sys
 
 import pythonparser
+from pythonparser import algorithm
 
 from grumpy.compiler import imputil
 from grumpy.compiler import util
@@ -29,6 +30,26 @@ from grumpy.compiler import util
 parser = argparse.ArgumentParser()
 parser.add_argument('script', help='Python source filename')
 parser.add_argument('-modname', default='__main__', help='Python module name')
+
+
+class ImportCollector(algorithm.Visitor):
+
+  # pylint: disable=invalid-name
+
+  def __init__(self, importer, future_node):
+    self.importer = importer
+    self.future_node = future_node
+    self.imports = []
+
+  def visit_Import(self, node):
+    self.imports.extend(self.importer.visit(node))
+
+  def visit_ImportFrom(self, node):
+    if node.module == '__future__':
+      if node != self.future_node:
+        raise util.LateFutureError(node)
+      return
+    self.imports.extend(self.importer.visit(node))
 
 
 def main(args):
@@ -52,16 +73,16 @@ def main(args):
     print >> sys.stderr, str(e)
     return 2
 
-  path = imputil.Path(gopath, args.modname, args.script,
-                      future_features.absolute_import)
-  visitor = imputil.ImportVisitor(path, future_node)
+  importer = imputil.Importer(gopath, args.modname, args.script,
+                              future_features.absolute_import)
+  collector = ImportCollector(importer, future_node)
   try:
-    visitor.visit(mod)
+    collector.visit(mod)
   except util.CompileError as e:
     print >> sys.stderr, str(e)
     return 2
   imports = set([args.modname])
-  for imp in visitor.imports:
+  for imp in collector.imports:
     if not imp.is_native:
       parts = imp.name.split('.')
       # Iterate over all packages and the leaf module.


### PR DESCRIPTION
Previously importing logic was spread across two classes: Path which
looked for files in a list of directories and ImportVisitor which
processed import nodes and used a Path to resolve modules. That became
cumbersome when attempting to support relative imports because now two
modes of module resolution were necessary and a "level" param carried
through the calls.

This change collapses the Path and ImportVisitor functionality into a
single Importer class that processes import nodes and resolves to
modules directly. This class is stateless which makes it easier to test
and work with. It will also make it easier to implement relative imports
since the node processing and module resolution are integrated.