### PR TITLE
Fix .d file generation on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,10 @@ $(COMPILER_PASS_FILES): %.pass: %.py $(COMPILER) $(COMPILER_TEST_SRCS)
 	@touch $@
 	@echo compiler/`basename $*` PASS
 
+# NOTE: In the regex below we use (\.|$) instead of \> because the latter is
+# not available in the awk available on OS X.
 $(COMPILER_D_FILES): $(PY_DIR)/%.d: $(PY_DIR)/%.py $(COMPILER_SRCS) $(PYTHONPARSER_SRCS)
-	@$(PYTHON) -m modulefinder $< | awk '{if (match($$2, /^grumpy\>/)) { print "$(PY_DIR)/$*.pass: " substr($$3, length("$(ROOT_DIR)/") + 1) }}' > $@
+	@$(PYTHON) -m modulefinder $< | awk '{if (match($$2, /^grumpy(\.|$$)/)) { print "$(PY_DIR)/$*.pass: " substr($$3, length("$(ROOT_DIR)/") + 1) }}' > $@
 
 -include $(COMPILER_D_FILES)
 


### PR DESCRIPTION
The awk script that was processing modulefinder output to produce .d
files was not working because it was using \> to match a word ending,
but that is only supported in GNU awk:

https://www.math.utah.edu/docs/info/gawk_5.html#SEC29

Switched that for a more portable equivalent.