### PR TITLE
Fixes #290: pyPrint accepts any filelike, with sys.stdout fallback

### DIFF
--- a/lib/sys.py
+++ b/lib/sys.py
@@ -88,10 +88,10 @@ class _SysModule(object):
             SysmoduleDict[k] = globals()[k]
     def __setattr__(self, name, value):
         SysmoduleDict[name] = value
-    def __getattr__(self, name):
+    def __getattribute__(self, name):   # TODO: replace w/ __getattr__ when implemented
         resp = SysmoduleDict.get(name)
         if res is None and name not in SysmoduleDict:
-            return super(_SysModule, self).__getattr__(name)
+            return super(_SysModule, self).__getattribute__(name)
         return resp
 
 modules = SysModules

--- a/lib/sys.py
+++ b/lib/sys.py
@@ -21,7 +21,7 @@ from __go__.unicode import MaxRune
 
 argv = []
 for arg in Args:
-  argv.append(arg)
+    argv.append(arg)
 
 goversion = Version()
 maxint = MaxInt
@@ -34,35 +34,36 @@ warnoptions = []
 byteorder = 'little'
 
 class _Flags(object):
-  """Container class for sys.flags."""
-  debug = 0
-  py3k_warning = 0
-  division_warning = 0
-  division_new = 0
-  inspect = 0
-  interactive = 0
-  optimize = 0
-  dont_write_bytecode = 0
-  no_user_site = 0
-  no_site = 0
-  ignore_environment = 0
-  tabcheck = 0
-  verbose = 0
-  unicode = 0
-  bytes_warning = 0
-  hash_randomization = 0
+    """Container class for sys.flags."""
+    debug = 0
+    py3k_warning = 0
+    division_warning = 0
+    division_new = 0
+    inspect = 0
+    interactive = 0
+    optimize = 0
+    dont_write_bytecode = 0
+    no_user_site = 0
+    no_site = 0
+    ignore_environment = 0
+    tabcheck = 0
+    verbose = 0
+    unicode = 0
+    bytes_warning = 0
+    hash_randomization = 0
 
 
 flags = _Flags()
 
 
 def exc_info():
-  e, tb = __frame__().__exc_info__()  # pylint: disable=undefined-variable
-  t = None
-  if e:
-    t = type(e)
-  return t, e, tb
+    e, tb = __frame__().__exc_info__()  # pylint: disable=undefined-variable
+    t = None
+    if e:
+        t = type(e)
+    return t, e, tb
 
 
 def exit(code=None):  # pylint: disable=redefined-builtin
-  raise SystemExit(code)
+    raise SystemExit(code)
+

--- a/lib/sys.py
+++ b/lib/sys.py
@@ -20,7 +20,7 @@ from __go__.runtime import Version
 from __go__.unicode import MaxRune
 
 
-__all__ = ('stdin', 'stdout', 'stderr', 'argv', '_goversion',
+__all__ = ('stdin', 'stdout', 'stderr', 'argv', 'goversion',
            'maxint', 'maxsize', 'maxunicode', 'modules', 'py3kwarning',
            'warnoptions', 'byteorder', 'flags', 'exc_info', 'exit')
 
@@ -90,7 +90,7 @@ class _SysModule(object):
         SysmoduleDict[name] = value
     def __getattribute__(self, name):   # TODO: replace w/ __getattr__ when implemented
         resp = SysmoduleDict.get(name)
-        if res is None and name not in SysmoduleDict:
+        if resp is None and name not in SysmoduleDict:
             return super(_SysModule, self).__getattribute__(name)
         return resp
 

--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -562,7 +562,7 @@ func builtinPrint(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) 
 			// to the file descriptor probably
 		}
 	}
-	return nil, pyPrint(f, args, sep, end, file)
+	return nil, pyPrint(f, args, sep, end, file.ToObject())
 }
 
 func builtinRange(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
@@ -590,7 +590,7 @@ func builtinRawInput(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseExceptio
 	}
 
 	if len(args) == 1 {
-		err := pyPrint(f, args, "", "", Stdout)
+		err := pyPrint(f, args, "", "", Stdout.ToObject())
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -683,7 +683,7 @@ func Print(f *Frame, args Args, nl bool) *BaseException {
 	} else if len(args) > 0 {
 		end = " "
 	}
-	return pyPrint(f, args, " ", end, Stdout)
+	return pyPrint(f, args, " ", end, Stdout.ToObject())
 }
 
 // Repr returns a string containing a printable representation of o. This is
@@ -1258,29 +1258,38 @@ func hashNotImplemented(f *Frame, o *Object) (*Object, *BaseException) {
 }
 
 // pyPrint encapsulates the logic of the Python print function.
-func pyPrint(f *Frame, args Args, sep, end string, file *File) *BaseException {
+func pyPrint(f *Frame, args Args, sep, end string, filelike *Object) *BaseException {
+	writeFunc, raised := GetAttr(f, filelike, NewStr("write"), nil)
+	if raised != nil {
+		return raised
+	}
+
+	pySep := NewStr(sep)
+	pyEnd := NewStr(end)
+	callArgs := f.MakeArgs(1)
 	for i, arg := range args {
 		if i > 0 {
-			err := file.writeString(sep)
-			if err != nil {
-				return f.RaiseType(IOErrorType, err.Error())
+			callArgs[0] = pySep.ToObject()
+			_, raised := writeFunc.Call(f, callArgs, nil)
+			if raised != nil {
+				return raised
 			}
 		}
 
-		s, raised := ToStr(f, arg)
-		if raised != nil {
-			return raised
+		s, raised_ := ToStr(f, arg)
+		if raised_ != nil {
+			return raised_
 		}
 
-		err := file.writeString(s.Value())
-		if err != nil {
-			return f.RaiseType(IOErrorType, err.Error())
+		callArgs[0] = s.ToObject()
+		if _, raised := writeFunc.Call(f, callArgs, nil); raised != nil {
+			return raised
 		}
 	}
 
-	err := file.writeString(end)
-	if err != nil {
-		return f.RaiseType(IOErrorType, err.Error())
+	callArgs[0] = pyEnd.ToObject()
+	if 	_, raised := writeFunc.Call(f, callArgs, nil); raised != nil {
+		return raised
 	}
 
 	return nil

--- a/runtime/core.go
+++ b/runtime/core.go
@@ -683,7 +683,11 @@ func Print(f *Frame, args Args, nl bool) *BaseException {
 	} else if len(args) > 0 {
 		end = " "
 	}
-	return pyPrint(f, args, " ", end, Stdout.ToObject())
+	file, raised := SysmoduleDict.GetItemString(f, "stdout")
+	if raised != nil {
+		return raised
+	}
+	return pyPrint(f, args, " ", end, file)
 }
 
 // Repr returns a string containing a printable representation of o. This is

--- a/runtime/sysmodule.go
+++ b/runtime/sysmodule.go
@@ -15,7 +15,7 @@
 package grumpy
 
 var (
-	// Sysmodule is the  __dict__ of the native part of sys.py.
+	// SysmoduleDict is the  __dict__ of the native part of sys.py.
 	SysmoduleDict = newStringDict(map[string]*Object{
 		"__file__": NewStr("<native>").ToObject(),
 		"__name__": NewStr("_sys").ToObject(),

--- a/runtime/sysmodule.go
+++ b/runtime/sysmodule.go
@@ -1,0 +1,26 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grumpy
+
+var (
+	// Sysmodule is the  __dict__ of the native part of sys.py.
+	SysmoduleDict = newStringDict(map[string]*Object{
+		"__file__": NewStr("<native>").ToObject(),
+		"__name__": NewStr("_sys").ToObject(),
+		"stdin": Stdin.ToObject(),
+		"stdout": Stdout.ToObject(),
+		"stderr": Stderr.ToObject(),
+	})
+)

--- a/testing/sysmodule_test.py
+++ b/testing/sysmodule_test.py
@@ -1,0 +1,15 @@
+from StringIO import StringIO
+import sys
+
+print 'To sys.stdout'
+
+old_stdout = sys.stdout
+sio = StringIO()
+sys.stdout = sio
+
+print 'To replaced sys.stdout'
+
+sys.stdout = old_stdout
+print 'To original sys.stdout'
+
+assert sio.tell() == len('To replaced sys.stdout')+1, 'Should had printed to StringIO, not STDOUT'


### PR DESCRIPTION
Gets sys.stdout from SysmoduleDict['stdout'], that exists and could be replaced (after #302 got merged)

pyPrint allows any filelike *Object to be printed to.

TBD: Factor out the method invocation logic to some ``func (o *Object) Invoke(f *Frame, method *Str)``