### PR TITLE
Make __dict__ modifiable

### DIFF
--- a/runtime/builtin_types.go
+++ b/runtime/builtin_types.go
@@ -342,19 +342,13 @@ func builtinDir(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
 	}
 	d := NewDict()
 	o := args[0]
-	if o.dict != nil {
-		raised := seqForEach(f, o.dict.ToObject(), func(k *Object) *BaseException {
-			return d.SetItem(f, k, None)
-		})
-		if raised != nil {
+	if dict := o.Dict(); dict != nil {
+		if raised := d.Update(f, dict.ToObject()); raised != nil {
 			return nil, raised
 		}
 	}
 	for _, t := range o.typ.mro {
-		raised := seqForEach(f, t.dict.ToObject(), func(k *Object) *BaseException {
-			return d.SetItem(f, k, None)
-		})
-		if raised != nil {
+		if raised := d.Update(f, t.Dict().ToObject()); raised != nil {
 			return nil, raised
 		}
 	}

--- a/runtime/builtin_types_test.go
+++ b/runtime/builtin_types_test.go
@@ -53,7 +53,7 @@ func TestBuiltinDelAttr(t *testing.T) {
 
 func TestBuiltinFuncs(t *testing.T) {
 	f := NewRootFrame()
-	objectDir := ObjectType.dict.Keys(f)
+	objectDir := ObjectType.Dict().Keys(f)
 	objectDir.Sort(f)
 	fooType := newTestClass("Foo", []*Type{ObjectType}, newStringDict(map[string]*Object{"bar": None}))
 	fooTypeDir := NewList(objectDir.elems...)

--- a/runtime/core_test.go
+++ b/runtime/core_test.go
@@ -1164,6 +1164,20 @@ func TestToNative(t *testing.T) {
 	}
 }
 
+func BenchmarkGetAttr(b *testing.B) {
+	f := NewRootFrame()
+	attr := NewStr("bar")
+	fooType := newTestClass("Foo", []*Type{ObjectType}, NewDict())
+	foo := newObject(fooType)
+	if raised := SetAttr(f, foo, attr, NewInt(123).ToObject()); raised != nil {
+		panic(raised)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mustNotRaise(GetAttr(f, foo, attr, nil))
+	}
+}
+
 // SetAttr is tested in TestObjectSetAttr.
 
 func exceptionsAreEquivalent(e1 *BaseException, e2 *BaseException) bool {

--- a/runtime/frame.go
+++ b/runtime/frame.go
@@ -70,7 +70,7 @@ func (f *Frame) release() {
 		// TODO: Track cache depth and release memory.
 		f.frameCache, f.back = f, f.frameCache
 		// Clear pointers early.
-		f.dict = nil
+		f.setDict(nil)
 		f.globals = nil
 		f.code = nil
 	} else if f.back != nil {

--- a/runtime/native.go
+++ b/runtime/native.go
@@ -434,7 +434,7 @@ func getNativeType(rtype reflect.Type) *Type {
 				d[name] = newNativeField(name, i, t)
 			}
 		}
-		t.dict = newStringDict(d)
+		t.setDict(newStringDict(d))
 		// This cannot fail since we're defining simple classes.
 		if err := prepareType(t); err != "" {
 			logFatal(err)

--- a/runtime/native_test.go
+++ b/runtime/native_test.go
@@ -479,11 +479,11 @@ func TestNewNativeFieldChecksInstanceType(t *testing.T) {
 	}
 
 	// When its field property is assigned to a different type
-	property, raised := native.typ.dict.GetItemString(f, "foo")
+	property, raised := native.typ.Dict().GetItemString(f, "foo")
 	if raised != nil {
 		t.Fatal("Unexpected exception:", raised)
 	}
-	if raised := IntType.dict.SetItemString(f, "foo", property); raised != nil {
+	if raised := IntType.Dict().SetItemString(f, "foo", property); raised != nil {
 		t.Fatal("Unexpected exception:", raised)
 	}
 

--- a/runtime/super.go
+++ b/runtime/super.go
@@ -74,7 +74,7 @@ func superGetAttribute(f *Frame, o *Object, name *Str) (*Object, *BaseException)
 		}
 		// Now do normal mro lookup from the successor type.
 		for ; i < n; i++ {
-			dict := mro[i].dict
+			dict := mro[i].Dict()
 			res, raised := dict.GetItem(f, name.ToObject())
 			if raised != nil {
 				return nil, raised

--- a/runtime/type.go
+++ b/runtime/type.go
@@ -172,7 +172,7 @@ func prepareBuiltinType(typ *Type, init builtinTypeInit) {
 			}
 		}
 	}
-	typ.dict = newStringDict(dict)
+	typ.setDict(newStringDict(dict))
 	if err := prepareType(typ); err != "" {
 		logFatal(err)
 	}
@@ -287,7 +287,7 @@ func (t *Type) Name() string {
 
 // FullName returns t's fully qualified name including the module.
 func (t *Type) FullName(f *Frame) (string, *BaseException) {
-	moduleAttr, raised := t.dict.GetItemString(f, "__module__")
+	moduleAttr, raised := t.Dict().GetItemString(f, "__module__")
 	if raised != nil {
 		return "", raised
 	}
@@ -313,7 +313,7 @@ func (t *Type) isSubclass(super *Type) bool {
 
 func (t *Type) mroLookup(f *Frame, name *Str) (*Object, *BaseException) {
 	for _, t := range t.mro {
-		v, raised := t.dict.GetItem(f, name.ToObject())
+		v, raised := t.Dict().GetItem(f, name.ToObject())
 		if v != nil || raised != nil {
 			return v, raised
 		}

--- a/runtime/type_test.go
+++ b/runtime/type_test.go
@@ -26,7 +26,7 @@ func TestNewClass(t *testing.T) {
 	strBasisStructFunc := func(o *Object) *strBasisStruct { return (*strBasisStruct)(o.toPointer()) }
 	fooType := newBasisType("Foo", reflect.TypeOf(strBasisStruct{}), strBasisStructFunc, StrType)
 	defer delete(basisTypes, fooType.basis)
-	fooType.dict = NewDict()
+	fooType.setDict(NewDict())
 	prepareType(fooType)
 	cases := []struct {
 		wantBasis reflect.Type
@@ -66,7 +66,7 @@ func TestNewBasisType(t *testing.T) {
 	if typ.Type() != TypeType {
 		t.Errorf("got %q, want a type", typ.Type().Name())
 	}
-	if typ.dict != nil {
+	if typ.Dict() != nil {
 		t.Error("type's dict was expected to be nil")
 	}
 	wantBases := []*Type{ObjectType}
@@ -151,7 +151,7 @@ func TestPrepareType(t *testing.T) {
 	for _, cas := range cases {
 		typ := newBasisType("Foo", cas.basis, cas.basisFunc, cas.base)
 		defer delete(basisTypes, cas.basis)
-		typ.dict = NewDict()
+		typ.setDict(NewDict())
 		prepareType(typ)
 		cas.wantMro[0] = typ
 		if !reflect.DeepEqual(typ.mro, cas.wantMro) {
@@ -334,7 +334,7 @@ func TestTypeGetAttribute(t *testing.T) {
 	//   __metaclass__ = BarMeta
 	// bar = Bar()
 	barType := &Type{Object: Object{typ: barMetaType}, name: "Bar", basis: fooType.basis, bases: []*Type{fooType}}
-	barType.dict = newTestDict("bar", "Bar's bar", "foo", 101, "barsetter", setter, "barmetasetter", "NOT setter")
+	barType.setDict(newTestDict("bar", "Bar's bar", "foo", 101, "barsetter", setter, "barmetasetter", "NOT setter"))
 	bar := newObject(barType)
 	prepareType(barType)
 	cases := []invokeTestCase{


### PR DESCRIPTION
This requires serializing access to Object.dict via atomic operations.
From some quick benchmarking, this does not seem to make a significant
difference to attribute access times.