### PR TITLE
Small fix on bytearray.__repr__

### DIFF
--- a/runtime/bytearray.go
+++ b/runtime/bytearray.go
@@ -136,7 +136,7 @@ func byteArrayRepr(f *Frame, o *Object) (*Object, *BaseException) {
 	if raised != nil {
 		return nil, raised
 	}
-	return NewStr(fmt.Sprintf("bytearray(%s)", s.Value())).ToObject(), nil
+	return NewStr(fmt.Sprintf("bytearray(b%s)", s.Value())).ToObject(), nil
 }
 
 func byteArrayStr(f *Frame, o *Object) (*Object, *BaseException) {

--- a/runtime/bytearray_test.go
+++ b/runtime/bytearray_test.go
@@ -91,8 +91,8 @@ func TestByteArrayNative(t *testing.T) {
 
 func TestByteArrayRepr(t *testing.T) {
 	cases := []invokeTestCase{
-		{args: wrapArgs(newTestByteArray("")), want: NewStr("bytearray('')").ToObject()},
-		{args: wrapArgs(newTestByteArray("foo")), want: NewStr("bytearray('foo')").ToObject()},
+		{args: wrapArgs(newTestByteArray("")), want: NewStr("bytearray(b'')").ToObject()},
+		{args: wrapArgs(newTestByteArray("foo")), want: NewStr("bytearray(b'foo')").ToObject()},
 	}
 	for _, cas := range cases {
 		if err := runInvokeTestCase(wrapFuncForTest(Repr), &cas); err != "" {


### PR DESCRIPTION
a `b` is missing in `bytearray.__repr__()` output:
```
>> python -c "print bytearray(1).__repr__()"
bytearray(b'\x00')

>> echo "print bytearray(1).__repr__()"|make run
bytearray('\x00')
```