### PR TITLE
Use traceback.format_exc for top level exceptions

### DIFF
--- a/compiler/stmt_test.py
+++ b/compiler/stmt_test.py
@@ -452,8 +452,8 @@ class StatementVisitorTest(unittest.TestCase):
         finally:
           print 'bar'"""))
     self.assertEqual(1, result[0])
-    # Some platforms show "exit status 1" message so don't test strict equality.
-    self.assertIn('foo bar\nfoo bar\nException\n', result[1])
+    self.assertIn('foo bar\nfoo bar\n', result[1])
+    self.assertIn('Exception\n', result[1])
 
   def testWhile(self):
     self.assertEqual((0, '2\n1\n'), _GrumpRun(textwrap.dedent("""\

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -288,19 +288,17 @@ func RunMain(code *Code) int {
 	m := newModule("__main__", code.filename)
 	m.state = moduleStateInitializing
 	f := NewRootFrame()
+	f.code = code
+	f.globals = m.Dict()
 	if raised := SysModules.SetItemString(f, "__main__", m.ToObject()); raised != nil {
 		Stderr.writeString(raised.String())
 	}
-	_, e := code.Eval(f, m.Dict(), nil, nil)
+	_, e := code.fn(f, nil)
 	if e == nil {
 		return 0
 	}
 	if !e.isInstance(SystemExitType) {
-		s, raised := FormatException(f, e)
-		if raised != nil {
-			s = e.String()
-		}
-		Stderr.writeString(s)
+		Stderr.writeString(FormatExc(f))
 		return 1
 	}
 	f.RestoreExc(nil, nil)

--- a/runtime/weakref.go
+++ b/runtime/weakref.go
@@ -189,11 +189,7 @@ func weakRefFinalizeReferent(o *Object) {
 	for i := numCallbacks - 1; i >= 0; i-- {
 		f := NewRootFrame()
 		if _, raised := callbacks[i].Call(f, Args{r.ToObject()}, nil); raised != nil {
-			s, raised := FormatException(f, raised)
-			if raised != nil {
-				s = raised.String()
-			}
-			Stderr.writeString(s)
+			Stderr.writeString(FormatExc(f))
 		}
 	}
 }

--- a/tools/grumpc
+++ b/tools/grumpc
@@ -69,6 +69,13 @@ def main(args):
   mod_block = block.ModuleBlock(importer, full_package_name, args.script,
                                 py_contents, future_features)
   mod_block.add_native_import('grumpy')
+
+  # Import the traceback module in __main__ so that it's present in sys.modules.
+  traceback_package = None
+  has_main = args.modname == '__main__'
+  if has_main:
+    traceback_package = mod_block.add_import('traceback')
+
   visitor = stmt.StatementVisitor(mod_block, future_node)
   # Indent so that the module body is aligned with the goto labels.
   with visitor.writer.indent_block():
@@ -79,7 +86,6 @@ def main(args):
       return 2
 
   imports = dict(mod_block.imports)
-  has_main = args.modname == '__main__'
   if has_main:
     imports['os'] = block.Package('os')
 
@@ -93,6 +99,11 @@ def main(args):
   writer.write('func initModule(πF *πg.Frame, '
                '_ []*πg.Object) (*πg.Object, *πg.BaseException) {')
   with writer.indent_block():
+    if traceback_package:
+      writer.write_tmpl(textwrap.dedent("""\
+        if _, e := πg.ImportModule(πF, "traceback", []*πg.Code{$tb.Code}); e != nil {
+        \treturn nil, e
+        }"""), tb=traceback_package.alias)
     for s in sorted(mod_block.strings):
       writer.write('ß{} := πg.InternStr({})'.format(s, util.go_str(s)))
     writer.write_temp_decls(mod_block)


### PR DESCRIPTION
This change makes it so that all Grumpy binaries import the traceback
module and then updates grumpy.FormatException (now FormatExc) to use
traceback.format_exc if the traceback module is present in SysModules.