### PR TITLE
Issue where with stmt raises when exc_info is set

### DIFF
--- a/compiler/stmt.py
+++ b/compiler/stmt.py
@@ -503,7 +503,10 @@ class StatementVisitor(algorithm.Visitor):
           self.block.alloc_temp('*πg.Type') as t:
         # temp := exit(mgr, *sys.exec_info())
         tmpl = """\
-            $exc, $tb = πF.ExcInfo()
+            $exc, $tb = nil, nil
+            if πE != nil {
+            \t$exc, $tb = πF.ExcInfo()
+            }
             if $exc != nil {
             \t$t = $exc.Type()
             \tif $swallow_exc, πE = $exit_func.Call(πF, πg.Args{$mgr, $t.ToObject(), $exc.ToObject(), $tb.ToObject()}, nil); πE != nil {

--- a/testing/with_test.py
+++ b/testing/with_test.py
@@ -180,3 +180,18 @@ with EnterResult([1, (2, 3)]) as (h, (i, j)):
 assert h == 1
 assert i == 2
 assert j == 3
+
+
+# This checks for a bug where a with clause inside an except body raises an
+# exception because it was checking ExcInfo() to determine whether an exception
+# occurred.
+class Foo(object):
+  def __enter__(self):
+    pass
+  def __exit__(self, *args):
+    pass
+try:
+  raise AssertionError
+except:
+  with Foo():
+    pass


### PR DESCRIPTION
Found this issue while working on something else: if exc_info is set
(e.g. in an except clause) then the finally part of the with statement
will re-raise that exception because it thinks the with body was
responsible for the exception.

Fix is to check whether πE is set instead of checking exc_info when
entering the finally part of the with block.