### PR TITLE
Return only status on closing popen()

### DIFF
--- a/lib/os/__init__.py
+++ b/lib/os/__init__.py
@@ -136,10 +136,7 @@ class _Popen(object):
     state, err = self.result
     if err:
       raise OSError(err.Error())
-    result = _encode_wait_result(state.Sys())
-    if not result:
-      return None
-    return result 
+    return state.Sys() 
 
 
 def popen(command, mode='r'):

--- a/lib/os/__init__.py
+++ b/lib/os/__init__.py
@@ -139,7 +139,7 @@ class _Popen(object):
     result = _encode_wait_result(state.Sys())
     if not result:
       return None
-    return state.status 
+    return result 
 
 
 def popen(command, mode='r'):

--- a/lib/os/__init__.py
+++ b/lib/os/__init__.py
@@ -139,7 +139,7 @@ class _Popen(object):
     result = _encode_wait_result(state.Sys())
     if not result:
       return None
-    return state.Pid(), result
+    return state.status 
 
 
 def popen(command, mode='r'):

--- a/lib/os_test.py
+++ b/lib/os_test.py
@@ -102,12 +102,13 @@ def TestFDOpenOSError():
 
 
 def TestPopenRead():
+  f = os.popen('qux')
+  assert f.close() == 32512
   f = os.popen('echo hello')
   try:
     assert f.read() == 'hello\n'
   finally:
-    stat = f.close()
-    assert stat == 0
+    assert f.close() == 0
 
 
 def TestPopenWrite():

--- a/lib/os_test.py
+++ b/lib/os_test.py
@@ -106,7 +106,8 @@ def TestPopenRead():
   try:
     assert f.read() == 'hello\n'
   finally:
-    f.close()
+    stat = f.close()
+    assert stat == 0
 
 
 def TestPopenWrite():


### PR DESCRIPTION
It should return only `status`, on closing the `popen()`:
```
>> python -c "import os; print os.popen('foo 2>&1').close()"
32512

>> echo "import os; print os.popen('foo 2>&1').close()"|make run
(23105, -1)
```