### PR TITLE
Import module deps only in main, not packages

### DIFF
--- a/compiler/block.py
+++ b/compiler/block.py
@@ -172,18 +172,7 @@ class ModuleBlock(Block):
   def resolve_name(self, writer, name):
     return self._resolve_global(writer, name)
 
-  def add_import(self, name):
-    """Register the named Go package for import.
-
-    Args:
-      name: The fully qualified Go package name.
-    Returns:
-      A Package representing the import.
-    """
-    return self.add_native_import('__python__/' + name)
-
-  def add_native_import(self, name):
-    alias = None
+  def add_native_import(self, name, alias=None):
     if name == 'grumpy':
       alias = 'πg'
     if name in self.imports:

--- a/compiler/block_test.py
+++ b/compiler/block_test.py
@@ -41,25 +41,6 @@ class PackageTest(unittest.TestCase):
 
 class BlockTest(unittest.TestCase):
 
-  def testAddImport(self):
-    module_block = _MakeModuleBlock()
-    func1_block = block.FunctionBlock(module_block, 'func1', {}, False)
-    func2_block = block.FunctionBlock(func1_block, 'func2', {}, False)
-    package = func2_block.root.add_import('foo/bar')
-    self.assertEqual(package.name, '__python__/foo/bar')
-    self.assertEqual(package.alias, 'π___python__ΓfooΓbar')
-    self.assertEqual(module_block.imports, {'__python__/foo/bar': package})
-
-  def testAddImportRepeated(self):
-    b = _MakeModuleBlock()
-    package = b.root.add_import('foo')
-    self.assertEqual(package.name, '__python__/foo')
-    self.assertEqual(package.alias, 'π___python__Γfoo')
-    self.assertEqual(b.imports, {'__python__/foo': package})
-    package2 = b.root.add_import('foo')
-    self.assertIs(package, package2)
-    self.assertEqual(b.imports, {'__python__/foo': package})
-
   def testLoop(self):
     b = _MakeModuleBlock()
     loop = b.push_loop()

--- a/runtime/module_test.go
+++ b/runtime/module_test.go
@@ -40,7 +40,7 @@ func TestImportModule(t *testing.T) {
 			return nil, f.RaiseType(AssertionErrorType, "circular imported recursively")
 		}
 		circularImported = true
-		if _, raised := ImportModule(f, "circular", []*Code{fooCode}); raised != nil {
+		if _, raised := ImportModule(f, "circular"); raised != nil {
 			return nil, raised
 		}
 		return None, nil
@@ -55,41 +55,47 @@ func TestImportModule(t *testing.T) {
 	// NOTE: This test progressively evolves sys.modules, checking after
 	// each test case that it's populated appropriately.
 	oldSysModules := SysModules
+	oldModuleRegistry := moduleRegistry
 	defer func() {
 		SysModules = oldSysModules
+		moduleRegistry = oldModuleRegistry
 	}()
 	SysModules = newStringDict(map[string]*Object{"invalid": invalidModule})
+	moduleRegistry = map[string]*Code{
+		"foo":         fooCode,
+		"foo.bar":     barCode,
+		"foo.bar.baz": bazCode,
+		"foo.qux":     quxCode,
+		"raises":      raisesCode,
+		"circular":    circularCode,
+		"clear":       clearCode,
+	}
 	cases := []struct {
 		name           string
-		codeObjs       []*Code
 		want           *Object
 		wantExc        *BaseException
 		wantSysModules *Dict
 	}{
 		{
-			"foo.bar",
-			[]*Code{},
+			"noexist",
 			nil,
-			mustCreateException(SystemErrorType, "invalid import: foo.bar"),
+			mustCreateException(ImportErrorType, "noexist"),
 			newStringDict(map[string]*Object{"invalid": invalidModule}),
 		},
 		{
 			"invalid",
-			[]*Code{fooCode},
 			NewTuple(invalidModule).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{"invalid": invalidModule}),
 		},
 		{
 			"raises",
-			[]*Code{raisesCode},
 			nil,
 			mustCreateException(ValueErrorType, "uh oh"),
 			newStringDict(map[string]*Object{"invalid": invalidModule}),
 		},
 		{
 			"foo",
-			[]*Code{fooCode},
 			NewTuple(foo.ToObject()).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{
@@ -99,7 +105,6 @@ func TestImportModule(t *testing.T) {
 		},
 		{
 			"foo",
-			[]*Code{fooCode},
 			NewTuple(foo.ToObject()).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{
@@ -109,7 +114,6 @@ func TestImportModule(t *testing.T) {
 		},
 		{
 			"foo.qux",
-			[]*Code{fooCode, quxCode},
 			NewTuple(foo.ToObject(), qux.ToObject()).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{
@@ -120,7 +124,6 @@ func TestImportModule(t *testing.T) {
 		},
 		{
 			"foo.bar.baz",
-			[]*Code{fooCode, barCode, bazCode},
 			NewTuple(foo.ToObject(), bar.ToObject(), baz.ToObject()).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{
@@ -133,7 +136,6 @@ func TestImportModule(t *testing.T) {
 		},
 		{
 			"circular",
-			[]*Code{circularCode},
 			NewTuple(circularTestModule).ToObject(),
 			nil,
 			newStringDict(map[string]*Object{
@@ -147,7 +149,6 @@ func TestImportModule(t *testing.T) {
 		},
 		{
 			"clear",
-			[]*Code{clearCode},
 			nil,
 			mustCreateException(ImportErrorType, "Loaded module clear not found in sys.modules"),
 			newStringDict(map[string]*Object{
@@ -161,7 +162,7 @@ func TestImportModule(t *testing.T) {
 		},
 	}
 	for _, cas := range cases {
-		mods, raised := ImportModule(f, cas.name, cas.codeObjs)
+		mods, raised := ImportModule(f, cas.name)
 		var got *Object
 		if raised == nil {
 			got = NewTuple(mods...).ToObject()

--- a/tools/grumpc
+++ b/tools/grumpc
@@ -70,12 +70,6 @@ def main(args):
                                 py_contents, future_features)
   mod_block.add_native_import('grumpy')
 
-  # Import the traceback module in __main__ so that it's present in sys.modules.
-  traceback_package = None
-  has_main = args.modname == '__main__'
-  if has_main:
-    traceback_package = mod_block.add_import('traceback')
-
   visitor = stmt.StatementVisitor(mod_block, future_node)
   # Indent so that the module body is aligned with the goto labels.
   with visitor.writer.indent_block():
@@ -85,25 +79,14 @@ def main(args):
       print >> sys.stderr, str(e)
       return 2
 
-  imports = dict(mod_block.imports)
-  if has_main:
-    imports['os'] = block.Package('os')
-
   writer = util.Writer(sys.stdout)
   package_name = args.modname.split('.')[-1]
-  if has_main:
-    package_name = 'main'
   writer.write('package {}'.format(package_name))
-  writer.write_import_block(imports)
+  writer.write_import_block(mod_block.imports)
 
   writer.write('func initModule(πF *πg.Frame, '
                '_ []*πg.Object) (*πg.Object, *πg.BaseException) {')
   with writer.indent_block():
-    if traceback_package:
-      writer.write_tmpl(textwrap.dedent("""\
-        if _, e := πg.ImportModule(πF, "traceback", []*πg.Code{$tb.Code}); e != nil {
-        \treturn nil, e
-        }"""), tb=traceback_package.alias)
     for s in sorted(mod_block.strings):
       writer.write('ß{} := πg.InternStr({})'.format(s, util.go_str(s)))
     writer.write_temp_decls(mod_block)
@@ -111,17 +94,11 @@ def main(args):
   writer.write('}')
   writer.write('var Code *πg.Code')
 
-  if has_main:
-    writer.write_tmpl(textwrap.dedent("""\
-      func main() {
-      \tCode = πg.NewCode("<module>", $script, nil, 0, initModule)
-      \tπ_os.Exit(πg.RunMain(Code))
-      }"""), script=util.go_str(args.script))
-  else:
-    writer.write_tmpl(textwrap.dedent("""\
-      func init() {
-      \tCode = πg.NewCode("<module>", $script, nil, 0, initModule)
-      }"""), script=util.go_str(args.script))
+  writer.write_tmpl(textwrap.dedent("""\
+    func init() {
+    \tCode = πg.NewCode("<module>", $script, nil, 0, initModule)
+    \tπg.RegisterModule($modname, Code)
+    }"""), script=util.go_str(args.script), modname=util.go_str(args.modname))
   return 0
 
 

--- a/tools/grumprun
+++ b/tools/grumprun
@@ -22,46 +22,85 @@ Usage: $ grumprun -m <module>             # Run the named module.
 
 import argparse
 import os
+import random
+import shutil
 import string
 import subprocess
 import sys
 import tempfile
 
+from grumpy.compiler import imputil
+
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-m', '--module', help='Run the named module')
+parser.add_argument('-m', '--modname', help='Run the named module')
 
 module_tmpl = string.Template("""\
 package main
 import (
 \t"os"
 \t"grumpy"
-\t"__python__/$package"
+\tmod "$package"
+$imports
 )
 func main() {
-\tos.Exit(grumpy.RunMain($alias.Code))
+\tgrumpy.ImportModule(grumpy.NewRootFrame(), "traceback")
+\tos.Exit(grumpy.RunMain(mod.Code))
 }
 """)
 
 
 def main(args):
+  gopath = os.getenv('GOPATH', None)
+  if not gopath:
+    print >> sys.stderr, 'GOPATH not set'
+    return 1
+
+  modname = args.modname
+  workdir = tempfile.mkdtemp()
   try:
-    fd, path = tempfile.mkstemp(suffix='.go')
-    if args.module:
-      with os.fdopen(fd, 'w') as f:
-        package = args.module.replace('.', '/')
-        alias = package.split('/')[-1]
-        f.write(module_tmpl.substitute(package=package, alias=alias))
+    if modname:
+      # Find the script associated with the given module.
+      for d in gopath.split(os.pathsep):
+        script = imputil.find_script(
+            os.path.join(d, 'src', '__python__'), modname)
+        if script:
+          break
+      else:
+        print >> sys.stderr, "can't find module", modname
+        return 1
     else:
+      # Generate a dummy python script on the GOPATH.
+      modname = ''.join(random.choice(string.ascii_letters) for _ in range(16))
+      py_dir = os.path.join(workdir, 'src', '__python__')
+      mod_dir = os.path.join(py_dir, modname)
+      os.makedirs(mod_dir)
+      script = os.path.join(py_dir, 'module.py')
+      with open(script, 'w') as f:
+        f.write(sys.stdin.read())
+      gopath = gopath + os.pathsep + workdir
+      os.putenv('GOPATH', gopath)
+      # Compile the dummy script to Go using grumpc.
+      fd = os.open(os.path.join(mod_dir, 'module.go'), os.O_WRONLY | os.O_CREAT)
       try:
-        p = subprocess.Popen('grumpc /dev/stdin', stdout=fd, shell=True)
+        p = subprocess.Popen('grumpc ' + script, stdout=fd, shell=True)
         if p.wait():
           return 1
       finally:
         os.close(fd)
-    return subprocess.Popen('go run ' + path, shell=True).wait()
+
+    names = imputil.calculate_transitive_deps(modname, script, gopath)
+    # Make sure traceback is available in all Python binaries.
+    names.add('traceback')
+    go_main = os.path.join(workdir, 'main.go')
+    package = '__python__/' + modname.replace('.', '/')
+    imports = ''.join('\t_ "__python__/' + name.replace('.', '/') + '"\n'
+                      for name in names)
+    with open(go_main, 'w') as f:
+      f.write(module_tmpl.substitute(package=package, imports=imports))
+    return subprocess.Popen('go run ' + go_main, shell=True).wait()
   finally:
-    os.remove(path)
+    shutil.rmtree(workdir)
 
 
 if __name__ == '__main__':

--- a/tools/pydeps
+++ b/tools/pydeps
@@ -22,33 +22,11 @@ import sys
 
 from grumpy.compiler import imputil
 from grumpy.compiler import util
-from grumpy import pythonparser
-from grumpy.pythonparser import algorithm
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument('script', help='Python source filename')
 parser.add_argument('-modname', default='__main__', help='Python module name')
-
-
-class ImportCollector(algorithm.Visitor):
-
-  # pylint: disable=invalid-name
-
-  def __init__(self, importer, future_node):
-    self.importer = importer
-    self.future_node = future_node
-    self.imports = []
-
-  def visit_Import(self, node):
-    self.imports.extend(self.importer.visit(node))
-
-  def visit_ImportFrom(self, node):
-    if node.module == '__future__':
-      if node != self.future_node:
-        raise util.LateFutureError(node)
-      return
-    self.imports.extend(self.importer.visit(node))
 
 
 def main(args):
@@ -57,38 +35,25 @@ def main(args):
     print >> sys.stderr, 'GOPATH not set'
     return 1
 
-  with open(args.script) as py_file:
-    py_contents = py_file.read()
   try:
-    mod = pythonparser.parse(py_contents)
+    imports = imputil.collect_imports(args.modname, args.script, gopath)
   except SyntaxError as e:
     print >> sys.stderr, '{}: line {}: invalid syntax: {}'.format(
         e.filename, e.lineno, e.text)
     return 2
-
-  try:
-    future_node, future_features = imputil.parse_future_features(mod)
   except util.CompileError as e:
     print >> sys.stderr, str(e)
     return 2
 
-  importer = imputil.Importer(gopath, args.modname, args.script,
-                              future_features.absolute_import)
-  collector = ImportCollector(importer, future_node)
-  try:
-    collector.visit(mod)
-  except util.CompileError as e:
-    print >> sys.stderr, str(e)
-    return 2
-  imports = set([args.modname])
-  for imp in collector.imports:
+  names = set([args.modname])
+  for imp in imports:
     if not imp.is_native:
       parts = imp.name.split('.')
       # Iterate over all packages and the leaf module.
       for i in xrange(len(parts)):
         name = '.'.join(parts[:i+1])
-        if name not in imports:
-          imports.add(name)
+        if name not in names:
+          names.add(name)
           print name
 
 


### PR DESCRIPTION
This implements option #2 in:
https://github.com/google/grumpy/issues/287

Basically, importing of packages corresponding to Python modules now
does not happen in the generated code for the module. Instead, these
imports only happen in the main Go package.

This simplifies grumpc, since it does not need to track imports for
the Python modules it imports. That work is now done in grumprun, which
determines the transitive dependencies and imports all those packages in
the generated main Go file.