### PR TITLE
Fix 32bit compilation

### DIFF
--- a/tools/pkgc.go
+++ b/tools/pkgc.go
@@ -65,7 +65,11 @@ func getConst(name string, v constant.Value) string {
 	case constant.Int:
 		if constant.Sign(v) >= 0 {
 			if i, exact := constant.Uint64Val(v); exact {
-				if i > math.MaxInt64 {
+				if i < math.MaxInt8 {
+					format = "uint(%s)"
+				} else if i < math.MaxInt32 {
+					format = "uint32(%s)"
+				} else {
 					format = "uint64(%s)"
 				}
 			} else {

--- a/tools/pkgc.go
+++ b/tools/pkgc.go
@@ -75,6 +75,16 @@ func getConst(name string, v constant.Value) string {
 			} else {
 				format = "float64(%s)"
 			}
+		} else {
+			if i, exact := constant.Int64Val(v); exact {
+				if i > math.MinInt8 {
+					format = "int(%s)"
+				} else if i > math.MinInt32 {
+					format = "int32(%s)"
+				} else {
+					format = "int64(%s)"
+				}
+			}
 		}
 	case constant.Float:
 		format = "float64(%s)"


### PR DESCRIPTION
Related to https://github.com/golang/go/issues/23086#issuecomment-371017565

When trying to compile on 32bit CPU, the import of `__go__.math` fails:
```
$ echo 'print "Hello"' | make run --debug
...
Must remake target 'build/pkg/android_arm/__python__/__go__/math.a'.
 # __python__/__go__/math
build/src/__python__/__go__/math/module.go:273:54: constant 9223372036854775807 overflows int
build/src/__python__/__go__/math/module.go:288:54: constant 4294967295 overflows int
build/src/__python__/__go__/math/module.go:318:54: constant -9223372036854775808 overflows int 
make: *** [Makefile:260: build/pkg/android_arm/__python__/__go__/math.a] Error 2
$
```
Had not included a test as Travis CI have no such machines available